### PR TITLE
Fix update check URL: LUCIT-Systems-and-Development -> oliver-zehentleitner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 [How to upgrade to the latest version!](https://oliver-zehentleitner.github.io/unicorn-binance-rest-api/readme.html#installation-and-upgrade)
 
 ## 2.9.0.dev (development stage/unreleased/unstable)
+### Fixed
+- `get_latest_release_info()`: updated GitHub repo URL from `LUCIT-Systems-and-Development` to `oliver-zehentleitner`
 
 ## 2.9.0
 ## next

--- a/unicorn_binance_rest_api/manager.py
+++ b/unicorn_binance_rest_api/manager.py
@@ -664,12 +664,12 @@ class BinanceRestApiManager(object):
         """
         try:
             if self.socks5_proxy_address is not None and self.socks5_proxy_port is not None:
-                respond = requests.get('https://api.github.com/repos/LUCIT-Systems-and-Development/'
+                respond = requests.get('https://api.github.com/repos/oliver-zehentleitner/'
                                        'unicorn-binance-rest-api/releases/latest',
                                        proxies=self.request_socks5_proxies,
                                        verify=self.socks5_proxy_ssl_verification)
             else:
-                respond = requests.get('https://api.github.com/repos/LUCIT-Systems-and-Development/'
+                respond = requests.get('https://api.github.com/repos/oliver-zehentleitner/'
                                        'unicorn-binance-rest-api/releases/latest')
             latest_release_info = respond.json()
             return latest_release_info


### PR DESCRIPTION
## Summary

`get_latest_release_info()` was still querying the old LUCIT GitHub org for the update check. Updated both URL occurrences (with and without socks5 proxy) to point to `oliver-zehentleitner/unicorn-binance-rest-api`.