### PR TITLE
Fix AttributeError in get_latest_version when GitHub API request fails

### DIFF
--- a/unicorn_binance_rest_api/manager.py
+++ b/unicorn_binance_rest_api/manager.py
@@ -645,8 +645,9 @@ class BinanceRestApiManager(object):
         Get the version of the latest available release (cache time 1 hour)
         :return: str or False
         """
-        # Do a fresh request if status is None or last timestamp is older 1 hour
-        if self.last_update_check_github['status'].get('tag_name') is None or \
+        # Do a fresh request if status is not a dict, has no tag_name, or last timestamp is older 1 hour
+        if not isinstance(self.last_update_check_github['status'], dict) or \
+                self.last_update_check_github['status'].get('tag_name') is None or \
                 (self.last_update_check_github['timestamp']+(60*60) < time.time()):
             self.last_update_check_github['status'] = self.get_latest_release_info()
         if self.last_update_check_github['status']:


### PR DESCRIPTION
## Summary
- `get_latest_release_info()` returns `False` on failure
- `get_latest_version()` then calls `.get('tag_name')` on that `False`, causing `AttributeError: 'bool' object has no attribute 'get'`
- Fix: check `isinstance(status, dict)` before calling `.get()`

## Reproducer
Happens when GitHub API is unreachable or rate-limited during `BinanceRestApiManager.__init__()`.

```
File "manager.py", line 630, in is_update_availabe
File "manager.py", line 649, in get_latest_version
AttributeError: 'bool' object has no attribute 'get'
```