### PR TITLE
Add European Options Market Data API support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 [How to upgrade to the latest version!](https://oliver-zehentleitner.github.io/unicorn-binance-rest-api/readme.html#installation-and-upgrade)
 
 ## 2.9.1.dev (development stage/unreleased/unstable)
+### Added
+- Support for Binance European Options (Vanilla Options) Market Data API via `exchange="binance.com-vanilla-options"`
+- New exchange strings: `binance.com-vanilla-options`, `binance.com-vanilla-options-testnet`
+- Infrastructure: `OPTIONS_URL`, `OPTIONS_API_VERSION`, `_create_options_api_uri()`, `_request_options_api()`
+- `options_ping()` — `GET /eapi/v1/ping`
+- `options_time()` — `GET /eapi/v1/time`
+- `options_exchange_info()` — `GET /eapi/v1/exchangeInfo`
+- `options_order_book()` — `GET /eapi/v1/depth`
+- `options_recent_trades()` — `GET /eapi/v1/trades`
+- `options_block_trades()` — `GET /eapi/v1/blockTrades`
+- `options_klines()` — `GET /eapi/v1/klines`
+- `options_mark_price()` — `GET /eapi/v1/mark`
+- `options_ticker()` — `GET /eapi/v1/ticker`
+- `options_index_price()` — `GET /eapi/v1/index`
+- `options_exercise_history()` — `GET /eapi/v1/exerciseHistory`
+- `options_open_interest()` — `GET /eapi/v1/openInterest`
 
 ## 2.9.1
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 [Contributing](#contributing) | [Disclaimer](#disclaimer)
 
 A Python SDK to use the Binance REST API`s (com+testnet, com-margin+testnet, com-isolated_margin+testnet, 
-com-futures+testnet, us, tr) in a simple, fast, flexible, robust and fully-featured way. 
+com-futures+testnet, com-vanilla-options+testnet, us, tr) in a simple, fast, flexible, robust and fully-featured way. 
 
 Part of ['UNICORN Binance Suite'](https://github.com/oliver-zehentleitner/unicorn-binance-suite).
 
@@ -107,6 +107,8 @@ provides an API to the Binance REST API`s of
 [Binance Futures](https://binance-docs.github.io/apidocs/futures/en/#websocket-market-streams) 
 ([+Testnet](https://testnet.binancefuture.com)), 
 [Binance COIN-M Futures](https://binance-docs.github.io/apidocs/delivery/en/#change-log),
+[Binance European Options](https://developers.binance.com/docs/derivatives/option/general-info)
+([+Testnet](https://testnet.binancefuture.com)),
 [Binance US](https://github.com/binance-us/binance-official-api-docs) and
 [Binance TR](https://www.trbinance.com/apidocs) and needs to be used with a valid 
 [api_key and api_secret](https://technopathy.club/how-to-create-a-binance-api-key-and-api-secret-3bb5f47e360d)
@@ -133,6 +135,8 @@ combination.
 | [Binance USD-M Futures](https://www.binance.com)                   | `binance.com-futures`                 |
 | [Binance USD-M Futures Testnet](https://testnet.binancefuture.com) | `binance.com-futures-testnet`         |
 | [Binance Coin-M Futures](https://www.binance.com)                  | `binance.com-coin_futures`            |
+| [Binance European Options](https://www.binance.com)                | `binance.com-vanilla-options`         |
+| [Binance European Options Testnet](https://testnet.binancefuture.com) | `binance.com-vanilla-options-testnet` |
 | [Binance US](https://www.binance.us)                               | `binance.us`                          |
 | [Binance TR](https://www.trbinance.com)                            | `trbinance.com`                       |
 

--- a/unicorn_binance_rest_api/manager.py
+++ b/unicorn_binance_rest_api/manager.py
@@ -120,6 +120,8 @@ class BinanceRestApiManager(object):
     MARGIN_API_VERSION = 'v1'
     FUTURES_API_VERSION = 'v1'
     FUTURES_API_VERSION2 = "v2"
+    OPTIONS_URL = 'https://eapi.binance.com/eapi'
+    OPTIONS_API_VERSION = 'v1'
 
     SYMBOL_TYPE_SPOT = 'SPOT'
 
@@ -344,6 +346,24 @@ class BinanceRestApiManager(object):
                 self.FUTURES_DATA_URL = "https://fapi.trbinance.com/futures/data"
                 self.FUTURES_COIN_URL = "https://fapi.trbinance.com/fapi"
                 self.FUTURES_COIN_DATA_URL = "https://dapi.trbinance.com/futures/data"
+            elif self.exchange == "binance.com-vanilla-options":
+                self.API_URL = "https://api.binance.com/api"
+                self.MARGIN_API_URL = " https://api.binance.com/sapi"
+                self.WEBSITE_URL = "https://www.binance.com"
+                self.FUTURES_URL = "https://fapi.binance.com/fapi"
+                self.FUTURES_DATA_URL = "https://fapi.binance.com/futures/data"
+                self.FUTURES_COIN_URL = "https://fapi.binance.com/fapi"
+                self.FUTURES_COIN_DATA_URL = "https://dapi.binance.com/futures/data"
+                self.OPTIONS_URL = "https://eapi.binance.com/eapi"
+            elif self.exchange == "binance.com-vanilla-options-testnet":
+                self.API_URL = "https://testnet.binance.vision/api"
+                self.MARGIN_API_URL = " https://api.binance.com/sapi"
+                self.WEBSITE_URL = "https://testnet.binance.vision"
+                self.FUTURES_URL = "https://testnet.binancefuture.com/fapi"
+                self.FUTURES_DATA_URL = "https://testnet.binancefuture.com/futures/data"
+                self.FUTURES_COIN_URL = "https://testnet.binancefuture.com/dapi"
+                self.FUTURES_COIN_DATA_URL = "https://testnet.binancefuture.com/futures/data"
+                self.OPTIONS_URL = "https://testnet.binancefuture.com/eapi"
             elif self.exchange:
                 # Unknown Exchange
                 error_msg = f"Unknown exchange '{str(self.exchange)}'! Read the docs to see a list of supported " \
@@ -572,6 +592,13 @@ class BinanceRestApiManager(object):
     def _request_futures_coin_data_api(self, method, path, signed=False, version=1, throw_exception=True, **kwargs):
         uri = self._create_futures_coin_data_api_url(path, version=version)
 
+        return self._request(method, uri, signed, True, throw_exception=throw_exception, **kwargs)
+
+    def _create_options_api_uri(self, path: str) -> str:
+        return self.OPTIONS_URL + '/' + self.OPTIONS_API_VERSION + '/' + path
+
+    def _request_options_api(self, method, path, signed=False, throw_exception=True, **kwargs):
+        uri = self._create_options_api_uri(path)
         return self._request(method, uri, signed, True, throw_exception=throw_exception, **kwargs)
 
     def _save_used_weight(self) -> bool:
@@ -7068,6 +7095,154 @@ class BinanceRestApiManager(object):
         }
         return self._request_futures_coin_api('delete', 'listenKey', signed=False, data=params,
                                               throw_exception=throw_exception, **kwargs)
+
+    # European Options Market Data endpoints
+    # https://developers.binance.com/docs/derivatives/option/market-data
+
+    def options_ping(self):
+        """Test connectivity to the Options REST API.
+
+        https://developers.binance.com/docs/derivatives/option/market-data
+
+        """
+        return self._request_options_api('get', 'ping')
+
+    def options_time(self):
+        """Check server time for Options API.
+
+        https://developers.binance.com/docs/derivatives/option/market-data
+
+        """
+        return self._request_options_api('get', 'time')
+
+    def options_exchange_info(self):
+        """Get current Options exchange trading rules and symbol information.
+
+        https://developers.binance.com/docs/derivatives/option/market-data/Exchange-Information
+
+        """
+        return self._request_options_api('get', 'exchangeInfo')
+
+    def options_order_book(self, **params):
+        """Get the Options order book.
+
+        https://developers.binance.com/docs/derivatives/option/market-data/Order-Book
+
+        :param symbol: required - e.g. BTC-260626-120000-C
+        :type symbol: str
+        :param limit: optional - Default 100, max 1000. Valid: [10, 20, 50, 100, 500, 1000]
+        :type limit: int
+
+        """
+        return self._request_options_api('get', 'depth', data=params)
+
+    def options_recent_trades(self, **params):
+        """Get recent Options trades.
+
+        https://developers.binance.com/docs/derivatives/option/market-data/Recent-Trades-List
+
+        :param symbol: required - e.g. BTC-260626-120000-C
+        :type symbol: str
+        :param limit: optional - Default 100, max 500
+        :type limit: int
+
+        """
+        return self._request_options_api('get', 'trades', data=params)
+
+    def options_block_trades(self, **params):
+        """Get recent Options block trades.
+
+        https://developers.binance.com/docs/derivatives/option/market-data/Recent-Block-Trades-List
+
+        :param symbol: optional - e.g. BTC-260626-120000-C
+        :type symbol: str
+        :param limit: optional - Default 100, max 500
+        :type limit: int
+
+        """
+        return self._request_options_api('get', 'blockTrades', data=params)
+
+    def options_klines(self, **params):
+        """Get Options kline/candlestick data.
+
+        https://developers.binance.com/docs/derivatives/option/market-data/Kline-Candlestick-Data
+
+        :param symbol: required - e.g. BTC-260626-120000-C
+        :type symbol: str
+        :param interval: required - e.g. 1m, 3m, 5m, 15m, 30m, 1h, 2h, 4h, 6h, 12h, 1d, 3d, 1w
+        :type interval: str
+        :param startTime: optional
+        :type startTime: long
+        :param endTime: optional
+        :type endTime: long
+        :param limit: optional - Default 500, max 1500
+        :type limit: int
+
+        """
+        return self._request_options_api('get', 'klines', data=params)
+
+    def options_mark_price(self, **params):
+        """Get Options mark price and greek info.
+
+        https://developers.binance.com/docs/derivatives/option/market-data/Option-Mark-Price
+
+        :param symbol: optional - e.g. BTC-260626-120000-C
+        :type symbol: str
+
+        """
+        return self._request_options_api('get', 'mark', data=params)
+
+    def options_ticker(self, **params):
+        """Get 24hr Options ticker price change statistics.
+
+        https://developers.binance.com/docs/derivatives/option/market-data/24hr-Ticker-Price-Change-Statistics
+
+        :param symbol: optional - e.g. BTC-260626-120000-C
+        :type symbol: str
+
+        """
+        return self._request_options_api('get', 'ticker', data=params)
+
+    def options_index_price(self, **params):
+        """Get spot index price for option underlying asset.
+
+        https://developers.binance.com/docs/derivatives/option/market-data/Symbol-Price-Ticker
+
+        :param underlying: required - e.g. BTCUSDT
+        :type underlying: str
+
+        """
+        return self._request_options_api('get', 'index', data=params)
+
+    def options_exercise_history(self, **params):
+        """Get historical exercise records.
+
+        https://developers.binance.com/docs/derivatives/option/market-data/Historical-Exercise-Records
+
+        :param underlying: optional - e.g. BTCUSDT
+        :type underlying: str
+        :param startTime: optional
+        :type startTime: long
+        :param endTime: optional
+        :type endTime: long
+        :param limit: optional - Default 100, max 100
+        :type limit: int
+
+        """
+        return self._request_options_api('get', 'exerciseHistory', data=params)
+
+    def options_open_interest(self, **params):
+        """Get open interest for specific underlying asset on specific expiration date.
+
+        https://developers.binance.com/docs/derivatives/option/market-data/Open-Interest
+
+        :param underlyingAsset: required - e.g. BTC
+        :type underlyingAsset: str
+        :param expiration: required - e.g. 221225
+        :type expiration: str
+
+        """
+        return self._request_options_api('get', 'openInterest', data=params)
 
     def get_all_coins_info(self, **params):
         """

--- a/unittest_binance_rest_api.py
+++ b/unittest_binance_rest_api.py
@@ -352,5 +352,78 @@ class TestBinanceUsRestManager(unittest.TestCase):
                     print(f"ERROR: {error_msg}")
 
 
+class TestBinanceOptionsRestManager(unittest.TestCase):
+    """Tests for European Options (Vanilla Options) Market Data API."""
+
+    @classmethod
+    def setUpClass(cls):
+        print(f"\r\nTestBinanceOptionsRestManager:")
+        cls.ubra = BinanceRestApiManager(exchange="binance.com-vanilla-options")
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.ubra.stop_manager()
+
+    def test_options_url_init(self):
+        """Test that OPTIONS_URL is set correctly for vanilla-options exchange."""
+        self.assertEqual(self.ubra.OPTIONS_URL, "https://eapi.binance.com/eapi")
+
+    def test_options_testnet_url_init(self):
+        """Test that OPTIONS_URL is set correctly for testnet."""
+        ubra_testnet = BinanceRestApiManager(exchange="binance.com-vanilla-options-testnet")
+        self.assertEqual(ubra_testnet.OPTIONS_URL, "https://testnet.binancefuture.com/eapi")
+        ubra_testnet.stop_manager()
+
+    def test_options_uri_builder(self):
+        """Test that _create_options_api_uri builds correct URIs."""
+        uri = self.ubra._create_options_api_uri('depth')
+        self.assertEqual(uri, "https://eapi.binance.com/eapi/v1/depth")
+        uri = self.ubra._create_options_api_uri('exchangeInfo')
+        self.assertEqual(uri, "https://eapi.binance.com/eapi/v1/exchangeInfo")
+
+    def test_options_ping(self):
+        """Test Options ping endpoint."""
+        result = self.ubra.options_ping()
+        self.assertIsNotNone(result)
+
+    def test_options_time(self):
+        """Test Options server time endpoint."""
+        result = self.ubra.options_time()
+        self.assertIn('serverTime', result)
+
+    def test_options_exchange_info(self):
+        """Test Options exchange info endpoint."""
+        result = self.ubra.options_exchange_info()
+        self.assertIn('optionSymbols', result)
+        self.assertIsInstance(result['optionSymbols'], list)
+        self.assertGreater(len(result['optionSymbols']), 0)
+
+    def test_options_order_book(self):
+        """Test Options order book endpoint."""
+        # Get a valid symbol first
+        info = self.ubra.options_exchange_info()
+        symbol = info['optionSymbols'][0]['symbol']
+        result = self.ubra.options_order_book(symbol=symbol, limit=10)
+        self.assertIn('lastUpdateId', result)
+        self.assertIn('bids', result)
+        self.assertIn('asks', result)
+        self.assertIn('T', result)
+
+    def test_options_mark_price(self):
+        """Test Options mark price endpoint."""
+        result = self.ubra.options_mark_price()
+        self.assertIsInstance(result, list)
+
+    def test_options_ticker(self):
+        """Test Options 24hr ticker endpoint."""
+        result = self.ubra.options_ticker()
+        self.assertIsInstance(result, list)
+
+    def test_options_index_price(self):
+        """Test Options index price endpoint."""
+        result = self.ubra.options_index_price(underlying="BTCUSDT")
+        self.assertIn('indexPrice', result)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- Add `binance.com-vanilla-options` + `binance.com-vanilla-options-testnet` exchange support
- Infrastructure: `OPTIONS_URL`, `OPTIONS_API_VERSION`, `_create_options_api_uri()`, `_request_options_api()` — designed for easy extension
- 11 Market Data methods: `options_ping`, `options_time`, `options_exchange_info`, `options_order_book`, `options_recent_trades`, `options_block_trades`, `options_klines`, `options_mark_price`, `options_ticker`, `options_index_price`, `options_exercise_history`, `options_open_interest`
- 10 unit tests, all verified live against `eapi.binance.com`
- Part 1/4 of Vanilla Options depth cache integration (UBRA → UBWA → UBLDC → UBDCC)

## Test plan
- [x] 26/26 unit tests pass (16 existing + 10 new)
- [x] Live verified: REST snapshot, exchange info, mark price, ticker, index price