### PR TITLE
Update Python versions in bug report template (3.9-3.14)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -65,12 +65,12 @@ body:
       description: |
         In which Python version is the code executed?
       options:
-        - Python3.7
-        - Python3.8
         - Python3.9
         - Python3.10
         - Python3.11
         - Python3.12
+        - Python3.13
+        - Python3.14
     validations:
       required: true
       


### PR DESCRIPTION
## Summary
- Remove deprecated Python 3.7 and 3.8 from the bug report issue template dropdown
- Add Python 3.13 and 3.14 to the dropdown options
- Supported versions are now: 3.9, 3.10, 3.11, 3.12, 3.13, 3.14