### PR TITLE
Update exchange list in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -116,16 +116,14 @@ body:
       options:
         - concerns all
         - binance.com
-        - binance.com-coin_futures
-        - binance.com-futures
-        - binance.com-futures-testnet
-        - binance.com-isolated_margin
-        - binance.com-isolated_margin-testnet
+        - binance.com-testnet
         - binance.com-margin
         - binance.com-margin-testnet
-        - binance.com-testnet
-        - binance.org
-        - binance.org-testnet 
+        - binance.com-isolated_margin
+        - binance.com-isolated_margin-testnet
+        - binance.com-futures
+        - binance.com-futures-testnet
+        - binance.com-coin_futures
         - binance.us
         - trbinance.com
     validations:


### PR DESCRIPTION
## Summary
- Remove dead `binance.org` and `binance.org-testnet` endpoints
- Reorder list to match logical grouping (spot, margin, futures)