### PR TITLE
Add vanilla options to exchange list in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -124,6 +124,8 @@ body:
         - binance.com-futures
         - binance.com-futures-testnet
         - binance.com-coin_futures
+        - binance.com-vanilla-options
+        - binance.com-vanilla-options-testnet
         - binance.us
         - trbinance.com
     validations:


### PR DESCRIPTION
## Summary
Add `binance.com-vanilla-options` and `binance.com-vanilla-options-testnet` to the exchange dropdown in the bug report template. UBRA supports the Options REST API (`eapi.binance.com`).