### PR TITLE
Drop ujson and lucit-channel legacy, refresh meta.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,21 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
   build badges. Removed the "There is no conda support until migration"
   placeholders. Install section is now a single
   `conda install -c conda-forge unicorn-binance-rest-api`.
+- Aligned dependency pins across `requirements.txt`, `setup.py`,
+  `pyproject.toml`, `environment.yml` and `meta.yaml` to the
+  newer minimums already used in `setup.py`
+  (`certifi>=2025.6.15`, `cryptography>=45.0.4`, `requests>=2.32.4`).
+- `meta.yaml`: removed the leftover `channels:` and `dependencies:`
+  blocks (they are `environment.yml` keys, not valid in `meta.yaml`).
+  Refreshed `about.description` by re-embedding the current `README.md`,
+  set `license: MIT` (was stale `LSOSL`).
+- `environment.yml`: dropped the `lucit` channel.
+### Removed
+- `ujson` dropped from `requirements.txt`, `setup.py`, `pyproject.toml`,
+  `environment.yml` and `meta.yaml`. UBRA never actually imports it —
+  the SDK decodes responses via `requests.Response.json()` (stdlib).
+  Suite-wide standard for JSON is now `orjson`, which UBRA doesn't need
+  either.
 ### Removed
 - `.github/workflows/build_conda.yml`: the conda-forge feedstock
   (`conda-forge/unicorn-binance-rest-api-feedstock`) now builds and

--- a/environment.yml
+++ b/environment.yml
@@ -1,21 +1,19 @@
 name: unicorn_binance_rest_api
 
 channels:
-  - lucit
   - conda-forge
   - defaults
 
 dependencies:
   - python>=3.9
-  - certifi>=2023.7.22
+  - certifi>=2025.6.15
   - colorama
-  - cryptography>=42.0.4
+  - cryptography>=45.0.4
   - cython
   - dateparser
   - pyopenssl
   - pysocks
-  - requests>=2.31.0
+  - requests>=2.32.4
   - regex
-  - ujson
   - pip:
     - service-identity

--- a/meta.yaml
+++ b/meta.yaml
@@ -22,39 +22,28 @@ requirements:
     - pip
     - python
     - mypy
-    - certifi >=2023.7.22
+    - certifi >=2025.6.15
     - colorama
-    - cryptography >=42.0.4
+    - cryptography >=45.0.4
     - cython
     - dateparser
     - pyopenssl
     - PySocks
     - regex
-    - requests >=2.31.0
+    - requests >=2.32.4
     - service_identity
-    - ujson
   run:
     - python
-    - certifi >=2023.7.22
+    - certifi >=2025.6.15
     - colorama
-    - cryptography >=42.0.4
+    - cryptography >=45.0.4
     - cython
     - dateparser
     - pyopenssl
     - PySocks
     - regex
-    - requests >=2.31.0
+    - requests >=2.32.4
     - service_identity
-    - ujson
-
-channels:
-  - lucit
-  - conda-forge
-  - default
-
-dependencies:
-  - anaconda-client
-  - conda-build
 
 test:
   imports:
@@ -65,51 +54,42 @@ test:
     - pip
 
 about:
-  summary: | 
-    A Python SDK to use the Binance REST API`s (com+testnet, com-margin+testnet, com-isolated_margin+testnet, 
+  summary: |
+    A Python SDK to use the Binance REST APIs (com+testnet, com-margin+testnet, com-isolated_margin+testnet,
     com-futures+testnet, us, tr) in a simple, fast, flexible, robust and fully-featured way.
   description: |
-    [![Get a UNICORN Binance Suite License](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-binance-suite/master/images/logo/LUCIT-UBS-License-Offer.png)](https://shop.lucit.services)
-    
-    [![Anaconda Release](https://img.shields.io/conda/v/lucit/unicorn-binance-rest-api?color=blue)](https://anaconda.org/lucit/unicorn-binance-rest-api)
-    [![GitHub Release](https://img.shields.io/github/release/LUCIT-Systems-and-Development/unicorn-binance-rest-api.svg?label=github)](https://github.com/oliver-zehentleitner/unicorn-binance-rest-api/releases)
+    [![GitHub Release](https://img.shields.io/github/release/oliver-zehentleitner/unicorn-binance-rest-api.svg?label=github&color=blue)](https://github.com/oliver-zehentleitner/unicorn-binance-rest-api/releases)
+    [![GitHub Downloads](https://img.shields.io/github/downloads/oliver-zehentleitner/unicorn-binance-rest-api/total?color=blue)](https://github.com/oliver-zehentleitner/unicorn-binance-rest-api/releases)
     [![PyPi Release](https://img.shields.io/pypi/v/unicorn-binance-rest-api?color=blue)](https://pypi.org/project/unicorn-binance-rest-api/)
-    [![Supported Python Version](https://img.shields.io/pypi/pyversions/unicorn_binance_rest_api.svg)](https://www.python.org/downloads/)
-    [![License](https://img.shields.io/badge/license-LSOSL-blue)](https://oliver-zehentleitner.github.io/unicorn-binance-rest-api/license.html)
     [![PyPi Downloads](https://pepy.tech/badge/unicorn-binance-rest-api)](https://pepy.tech/project/unicorn-binance-rest-api)
-    [![PyPi Downloads](https://pepy.tech/badge/unicorn-binance-rest_api/month)](https://pepy.tech/project/unicorn-binance-rest-api)
-    [![PyPi Downloads](https://pepy.tech/badge/unicorn-binance-rest_api/week)](https://pepy.tech/project/unicorn-binance-rest-api)
+    [![Conda-Forge Version](https://img.shields.io/conda/v/conda-forge/unicorn-binance-rest-api?color=blue&label=conda)](https://anaconda.org/conda-forge/unicorn-binance-rest-api)
+    [![Conda-Forge Downloads](https://img.shields.io/conda/dn/conda-forge/unicorn-binance-rest-api?color=blue&label=downloads)](https://anaconda.org/conda-forge/unicorn-binance-rest-api)
+    [![License](https://img.shields.io/github/license/oliver-zehentleitner/unicorn-binance-rest-api.svg?color=blue)](https://oliver-zehentleitner.github.io/unicorn-binance-rest-apilicense.html)
+    [![Supported Python Version](https://img.shields.io/pypi/pyversions/unicorn_binance_rest_api.svg)](https://www.python.org/downloads/)
     [![PyPI - Status](https://img.shields.io/pypi/status/unicorn_binance_rest_api.svg)](https://github.com/oliver-zehentleitner/unicorn-binance-rest-api/issues)
-    [![codecov](https://codecov.io/gh/LUCIT-Systems-and-Development/unicorn-binance-rest-api/branch/master/graph/badge.svg?token=5I03AZ3F5S)](https://codecov.io/gh/LUCIT-Systems-and-Development/unicorn-binance-rest-api)
+    [![codecov](https://codecov.io/gh/oliver-zehentleitner/unicorn-binance-rest-api/graph/badge.svg?token=P7XILPPSLU)](https://codecov.io/gh/oliver-zehentleitner/unicorn-binance-rest-api)
     [![CodeQL](https://github.com/oliver-zehentleitner/unicorn-binance-rest-api/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/oliver-zehentleitner/unicorn-binance-rest-api/actions/workflows/codeql-analysis.yml)
     [![Unittests](https://github.com/oliver-zehentleitner/unicorn-binance-rest-api/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/oliver-zehentleitner/unicorn-binance-rest-api/actions/workflows/unit-tests.yml)
     [![Build and Publish GH+PyPi](https://github.com/oliver-zehentleitner/unicorn-binance-rest-api/actions/workflows/build_wheels.yml/badge.svg)](https://github.com/oliver-zehentleitner/unicorn-binance-rest-api/actions/workflows/build_wheels.yml)
-    [![Build and Publish Anaconda](https://github.com/oliver-zehentleitner/unicorn-binance-rest-api/actions/workflows/build_conda.yml/badge.svg)](https://github.com/oliver-zehentleitner/unicorn-binance-rest-api/actions/workflows/build_conda.yml)
+    [![Conda-Forge Build](https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/unicorn-binance-rest-api-feedstock?branchName=main)](https://github.com/conda-forge/unicorn-binance-rest-api-feedstock)
     [![Read the Docs](https://img.shields.io/badge/read-%20docs-yellow)](https://oliver-zehentleitner.github.io/unicorn-binance-rest-api/)
     [![Read How To`s](https://img.shields.io/badge/read-%20howto-yellow)](https://technopathy.club)
     [![Github](https://img.shields.io/badge/source-github-cbc2c8)](https://github.com/oliver-zehentleitner/unicorn-binance-rest-api)
     [![Telegram](https://img.shields.io/badge/community-telegram-41ab8c)](https://t.me/unicorndevs)
-    [![Get Free Professional Support](https://img.shields.io/badge/chat-lucit%20support-004166)](https://www.lucit.tech/get-support.html)
     
-    [![LUCIT-UBRA-Banner](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-binance-rest-api/master/images/logo/LUCIT-UBRA-Banner-Readme.png)](https://github.com/oliver-zehentleitner/unicorn-binance-rest-api)
+    [![UBS-Banner](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-binance-suite/master/images/logo/UBS-Banner-Readme.png)](https://github.com/oliver-zehentleitner/unicorn-binance-suite)
     
     # UNICORN Binance REST API
     
     [Description](#description) | [Installation](#installation-and-upgrade) | [How To](#howto) |
     [Documentation](#documentation) | [Examples](#examples) | [Change Log](#change-log) | [Wiki](#wiki) | [Social](#social) |
     [Notifications](#receive-notifications) | [Bugs](#how-to-report-bugs-or-suggest-improvements) | 
-    [Contributing](#contributing) | [Disclaimer](#disclaimer) | [Commercial Support](#commercial-support)
+    [Contributing](#contributing) | [Disclaimer](#disclaimer)
     
-    A Python SDK by [LUCIT](https://www.lucit.tech) to use the Binance REST API`s (com+testnet, com-margin+testnet, 
-    com-isolated_margin+testnet, com-futures+testnet, us, tr) in a simple, fast, flexible, robust and fully-featured way. 
+    A Python SDK to use the Binance REST API`s (com+testnet, com-margin+testnet, com-isolated_margin+testnet, 
+    com-futures+testnet, com-vanilla-options+testnet, us, tr) in a simple, fast, flexible, robust and fully-featured way. 
     
     Part of ['UNICORN Binance Suite'](https://github.com/oliver-zehentleitner/unicorn-binance-suite).
-    
-    [Get help](https://www.lucit.tech/get-support.html) with the integration of the `UNICORN Binance Suite` modules!
-    
-    ## Get a UNICORN Binance Suite License
-    
-    To run modules of the *UNICORN Binance Suite* you need a [valid license](https://technopathy.club/how-to-obtain-and-use-a-unicorn-binance-suite-license-key-and-run-the-ubs-module-according-to-best-87b0088124a8#4ca4)!
     
     ## Receive Data from Binance REST API Endpoints
     
@@ -190,6 +170,8 @@ about:
     [Binance Futures](https://binance-docs.github.io/apidocs/futures/en/#websocket-market-streams) 
     ([+Testnet](https://testnet.binancefuture.com)), 
     [Binance COIN-M Futures](https://binance-docs.github.io/apidocs/delivery/en/#change-log),
+    [Binance European Options](https://developers.binance.com/docs/derivatives/option/general-info)
+    ([+Testnet](https://testnet.binancefuture.com)),
     [Binance US](https://github.com/binance-us/binance-official-api-docs) and
     [Binance TR](https://www.trbinance.com/apidocs) and needs to be used with a valid 
     [api_key and api_secret](https://technopathy.club/how-to-create-a-binance-api-key-and-api-secret-3bb5f47e360d)
@@ -216,6 +198,8 @@ about:
     | [Binance USD-M Futures](https://www.binance.com)                   | `binance.com-futures`                 |
     | [Binance USD-M Futures Testnet](https://testnet.binancefuture.com) | `binance.com-futures-testnet`         |
     | [Binance Coin-M Futures](https://www.binance.com)                  | `binance.com-coin_futures`            |
+    | [Binance European Options](https://www.binance.com)                | `binance.com-vanilla-options`         |
+    | [Binance European Options Testnet](https://testnet.binancefuture.com) | `binance.com-vanilla-options-testnet` |
     | [Binance US](https://www.binance.us)                               | `binance.us`                          |
     | [Binance TR](https://www.trbinance.com)                            | `trbinance.com`                       |
     
@@ -244,9 +228,7 @@ about:
     [GitHub](https://github.com/oliver-zehentleitner/unicorn-binance-rest-api)!
     
     ## Installation and Upgrade
-    The module requires Python 3.7 and runs smoothly up to and including Python 3.12.
-    
-    Anaconda packages are available from Python version 3.8 and higher, but only in the latest version!
+    The module requires Python 3.9 and runs smoothly up to and including Python 3.14.
     
     For the PyPy interpreter we offer packages only from Python version 3.9 and higher.
     
@@ -256,15 +238,13 @@ about:
     If you run into errors during the installation take a look [here](https://github.com/oliver-zehentleitner/unicorn-binance-suite/wiki/Installation).
     
     ### Packages are created automatically with GitHub Actions
-    When a new release is to be created, we start two GitHubActions: 
-    
-    - [Build and Publish Anaconda](https://github.com/oliver-zehentleitner/unicorn-binance-rest-api/actions/workflows/build_conda.yml)
-    - [Build and Publish GH+PyPi](https://github.com/oliver-zehentleitner/unicorn-binance-rest-api/actions/workflows/build_wheels.yml) 
-    
-    Both start virtual Windows/Linux/Mac servers provided by GitHub in the cloud with preconfigured environments and 
-    create the respective compilations and stub files, pack them into wheels and conda packages and then publish them on 
-    GitHub, PYPI and Anaconda. This is a transparent method that makes it possible to trace the source code behind a 
-    compilation.
+    When a new release is created, the
+    [Build and Publish GH+PyPi](https://github.com/oliver-zehentleitner/unicorn-binance-rest-api/actions/workflows/build_wheels.yml)
+    workflow spins up virtual Windows/Linux/Mac runners, compiles the Cython extensions, builds the
+    wheels and publishes them on GitHub and PyPI. The conda-forge feedstock
+    [conda-forge/unicorn-binance-rest-api-feedstock](https://github.com/conda-forge/unicorn-binance-rest-api-feedstock)
+    picks up the new PyPI release automatically and builds the Conda packages on its own infrastructure.
+    This is a transparent method that makes it possible to trace the source code behind a compilation.
     
     ### A Cython binary, PyPy or source code based CPython wheel of the latest version with `pip` from [PyPI](https://pypi.org/project/unicorn-binance-rest-api/)
     Our [Cython](https://cython.org/) and [PyPy](https://www.pypy.org/) Wheels are available on [PyPI](https://pypi.org/), 
@@ -292,29 +272,16 @@ about:
     #### Update
     `pip install unicorn-binance-rest-api --upgrade`
     
-    ### A Conda Package of the latest version with `conda` from [Anaconda](https://anaconda.org/lucit)
-    The `unicorn-binance-rest-api` package is also available as a Cython version for the `linux-64`, `osx-64` 
-    and `win-64` architectures with [Conda](https://docs.conda.io/en/latest/) through the 
-    [`lucit` channel](https://anaconda.org/lucit). 
-    
-    For optimal compatibility and performance, it is recommended to source the necessary dependencies from the 
-    [`conda-forge` channel](https://anaconda.org/conda-forge). 
-    
-    #### Installation
+    ### conda
     ```
-    conda config --add channels conda-forge
-    conda config --add channels lucit
-    conda install -c lucit unicorn-binance-rest-api
+    conda install -c conda-forge unicorn-binance-rest-api
     ```
-    
-    #### Update
-    `conda update -c lucit unicorn-binance-rest-api`
     
     ### From source of the latest release with PIP from [GitHub](https://github.com/oliver-zehentleitner/unicorn-binance-rest-api)
     #### Linux, macOS, ...
     Run in bash:
     
-    `pip install https://github.com/oliver-zehentleitner/unicorn-binance-rest-api/archive/$(curl -s https://api.github.com/repos/lucit-systems-and-development/unicorn-binance-rest-api/releases/latest | grep -oP '"tag_name": "\K(.*)(?=")').tar.gz --upgrade`
+    `pip install https://github.com/oliver-zehentleitner/unicorn-binance-rest-api/archive/$(curl -s https://api.github.com/repos/oliver-zehentleitner/unicorn-binance-rest-api/releases/latest | grep -oP '"tag_name": "\K(.*)(?=")').tar.gz --upgrade`
     
     #### Windows
     Use the below command with the version (such as 2.10.0) you determined 
@@ -349,7 +316,6 @@ about:
     - [Look here!](https://github.com/oliver-zehentleitner/unicorn-binance-rest-api/tree/master/examples/)
     
     ## Howto
-    - [How to Obtain and Use a Unicorn Binance Suite License Key and Run the UBS Module According to Best Practice](https://technopathy.club/how-to-obtain-and-use-a-unicorn-binance-suite-license-key-and-run-the-ubs-module-according-to-best-87b0088124a8)
     - [Restful Binance Requests in Python with UNICORN Binance REST API](https://technopathy.club/restful-binance-requests-in-python-with-unicorn-binance-rest-api-288f364e92a8)
     - [How to Download Klines from Binance using Python?](https://technopathy.club/how-to-download-data-from-binance-using-python-8f1b6e8f19f3)
     - [How to Connect to binance.com REST API using Python via a SOCKS5 Proxy](https://technopathy.club/how-to-connect-to-binance-com-rest-api-using-python-via-a-socks5-proxy-638dbbecacfd)
@@ -365,7 +331,7 @@ about:
     - [Discussions](https://github.com/oliver-zehentleitner/unicorn-binance-rest-api/discussions)
     - [https://t.me/unicorndevs](https://t.me/unicorndevs)
     - [https://dev.binance.vision](https://dev.binance.vision)
-    - [https://community.binance.org](https://community.binance.org)
+    - [https://forum.bnbchain.org/](https://forum.bnbchain.org/)
     
     ## Receive Notifications
     To receive notifications on available updates you can 
@@ -374,11 +340,6 @@ about:
     [own script](https://github.com/oliver-zehentleitner/unicorn-binance-rest-api/blob/master/examples/_archive/example_version_of_this_package.py) 
     with using 
     [`is_update_availabe()`](https://oliver-zehentleitner.github.io/unicorn-binance-rest-api/unicorn_binance_rest_api.html?highlight=is_update_availabe#unicorn_binance_rest_api.manager.BinanceRestApiManager.is_update_availabe).
-    
-    Follow us on [GitHub](https://github.com/oliver-zehentleitner), [Medium](https://technopathy.club/),
-    [YouTube](https://www.youtube.com/@LUCIT_Systems_and_Development), 
-    [LinkedIn](https://www.linkedin.com/company/lucit-systems-and-development), 
-    [X](https://twitter.com/LUCIT_SysDev) or [Facebook](https://www.facebook.com/lucit.systems.and.development)!
     
     To receive news (like inspection windows/maintenance) about the Binance API`s subscribe to their telegram groups: 
     
@@ -407,9 +368,18 @@ about:
     [this guide](https://github.com/oliver-zehentleitner/unicorn-binance-rest-api/blob/master/CONTRIBUTING.md).
      
     ### Contributors
-    [![Contributors](https://contributors-img.web.app/image?repo=lucit-systems-and-development/unicorn-binance-rest-api)](https://github.com/oliver-zehentleitner/unicorn-binance-rest-api/graphs/contributors)
+    [![Contributors](https://contributors-img.web.app/image?repo=oliver-zehentleitner/unicorn-binance-rest-api)](https://github.com/oliver-zehentleitner/unicorn-binance-rest-api/graphs/contributors)
     
     We ![love](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-binance-rest-api/master/images/misc/heart.png) open source!
+    
+    ---
+    
+    ## AI Integration
+    
+    This project provides a [`llms.txt`](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-binance-rest-api/refs/heads/master/llms.txt) file for AI tools (ChatGPT, Claude, Copilot, etc.) with structured 
+    usage instructions, code examples and module routing.
+    
+    ---
     
     ## Disclaimer
     This project is for informational purposes only. You should not construe this information or any other material as 
@@ -431,17 +401,11 @@ about:
     US services. For example, GitHub actions with UBS will not work without a SOCKS5 proxy, as they will inevitably run on 
     servers in the US and be blocked by Binance.com. Moreover, it also seems justified that traders, data scientists and 
     companies from the US analyze binance.com market data - as long as they do not trade there.
-    
-    ## Commercial Support
-    
-    [![Get professional and fast support](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-binance-suite/master/images/support/LUCIT-get-professional-and-fast-support.png)](https://www.lucit.tech/get-support.html)
-    
-    ***Do you need a developer, operator or consultant?*** [Contact us](https://www.lucit.tech/contact.html) for a non-binding initial consultation!
 
   dev_url: https://github.com/oliver-zehentleitner/unicorn-binance-rest-api
   doc_url: https://oliver-zehentleitner.github.io/unicorn-binance-rest-api
   home: https://github.com/oliver-zehentleitner/unicorn-binance-rest-api
-  license: LSOSL
+  license: MIT
   license_file: LICENSE
 
 extra:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,16 +22,15 @@ repository = "https://github.com/oliver-zehentleitner/unicorn-binance-rest-api"
 [tool.poetry.dependencies]
 python = ">=3.9.0"
 Cython = "*"
-requests = ">=2.31.0"
-certifi = ">=2023.7.22"
+requests = ">=2.32.4"
+certifi = ">=2025.6.15"
 colorama = "*"
-cryptography = ">=42.0.4"
+cryptography = ">=45.0.4"
 dateparser = "*"
 pyopenssl = "*"
 pysocks = "*"
 regex = "*"
 service-identity = "*"
-ujson = "*"
 
 [tool.poetry.dev-dependencies]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,14 +4,13 @@
 # ./pyproject.toml
 # ./setup.py
 
-certifi>=2023.7.22
+certifi>=2025.6.15
 colorama
-cryptography>=42.0.4
+cryptography>=45.0.4
 Cython
 dateparser
 pyOpenSSL
 PySocks
 regex
-requests>=2.31.0
+requests>=2.32.4
 service-identity
-ujson

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ setup(
      long_description_content_type="text/markdown",
      license='MIT',
      install_requires=["certifi>=2025.6.15", 'colorama', "cryptography>=45.0.4", 'dateparser', 'pyOpenSSL',
-                       "requests>=2.32.4", 'service-identity', 'ujson', 'regex', 'PySocks', 'Cython'],
+                       "requests>=2.32.4", 'service-identity', 'regex', 'PySocks', 'Cython'],
      keywords='',
      project_urls={
          'Howto': 'https://github.com/oliver-zehentleitner/unicorn-binance-rest-api#howto',


### PR DESCRIPTION
## ujson — dead weight
`ujson` was listed as a runtime dependency across **all five** dependency files, but is imported **nowhere** in the code:

```
$ grep -rE 'ujson|orjson|import json' unicorn_binance_rest_api/
(no matches)
```

UBRA decodes JSON via `requests.Response.json()` (stdlib), so no JSON library is required at all. Removed from `requirements.txt`, `setup.py`, `pyproject.toml`, `environment.yml` and `meta.yaml`. Suite-wide standard is `orjson` now anyway — but UBRA doesn't need that either.

## Dependency pins — drifted apart
The five dep files disagreed on minimums:
- `requests`: `>=2.31.0` in requirements.txt / pyproject.toml / environment.yml / meta.yaml, **`>=2.32.4`** in setup.py
- `certifi`: `>=2023.7.22` in four files, **`>=2025.6.15`** in setup.py
- `cryptography`: `>=42.0.4` in four files, **`>=45.0.4`** in setup.py

Unified everything on the newer `setup.py` values.

## meta.yaml cleanup
- Removed the stale `channels:` block (still listed `- lucit`) and the `dependencies:` block — both are `environment.yml` keys, conda-build silently ignores them in `meta.yaml`.
- `license: LSOSL` → `license: MIT` (matches `LICENSE` file and CHANGELOG 1.3.0 entry; LSOSL was reverted suite-wide).
- Re-embedded the current `README.md` into `about.description` with proper 4-space indentation so the anaconda.org page matches the GitHub README.

## environment.yml
- Dropped the `- lucit` channel.

## CHANGELOG
Entry added under `2.10.0.dev`.