### PR TITLE
environment.yml: drop defaults channel, README: reword PyPy line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## 2.10.0.dev (development stage/unreleased/unstable)
 ### Changed
+- `environment.yml`: dropped the `defaults` channel (conda-forge docs
+  recommend not mixing channels; Anaconda `defaults` requires a paid
+  license for enterprise use since 2024). Moved `service-identity` out
+  of the pip block into the main conda deps (now available on
+  conda-forge as `service_identity`), so the file is pure conda.
+- README: reworded the PyPy paragraph. The old sentence ("For the PyPy
+  interpreter we offer packages only from Python version 3.9 and
+  higher") made sense when we still shipped wheels for pre-3.9 CPython;
+  now that 3.9 is already the minimum for everything, it's just
+  noise. Replaced with a short "PyPy wheels are available for all
+  supported Python versions."
+
+### Changed
 - README: switched all conda references from the legacy `lucit` channel
   to `conda-forge`. Added conda-forge version / downloads / feedstock
   build badges. Removed the "There is no conda support until migration"

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ If you like the project, please [![star](https://raw.githubusercontent.com/olive
 ## Installation and Upgrade
 The module requires Python 3.9 and runs smoothly up to and including Python 3.14.
 
-For the PyPy interpreter we offer packages only from Python version 3.9 and higher.
+PyPy wheels are available for all supported Python versions.
 
 The current dependencies are listed 
 [here](https://github.com/oliver-zehentleitner/unicorn-binance-rest-api/blob/master/requirements.txt).

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,6 @@ name: unicorn_binance_rest_api
 
 channels:
   - conda-forge
-  - defaults
 
 dependencies:
   - python>=3.9
@@ -15,5 +14,4 @@ dependencies:
   - pysocks
   - requests>=2.32.4
   - regex
-  - pip:
-    - service-identity
+  - service_identity


### PR DESCRIPTION
Two small cleanups that came up during the suite-wide conda-forge migration review.

### environment.yml
- Dropped the `defaults` channel. conda-forge docs recommend not mixing `conda-forge` with `defaults` (ABI incompatibilities). Anaconda's `defaults` also requires a paid license for enterprise use since 2024.
- Moved `service-identity` out of the `pip:` block into the main conda deps (available on conda-forge as `service_identity`), so the file is pure conda and the solver resolves all deps in one pass. Mixing conda and pip in the same `environment.yml` is a known source of solver conflicts.

### README
Replaced:
> For the PyPy interpreter we offer packages only from Python version 3.9 and higher.

with:
> PyPy wheels are available for all supported Python versions.

The old wording made sense when we still shipped CPython wheels for pre-3.9. Now that 3.9 is the minimum for everything, spelling out that PyPy has the same floor is just noise.

Same PyPy rewording will be applied to the other UBS module READMEs.