### PR TITLE
Clean remaining LUCIT references outside the conda pipeline

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -26,9 +26,6 @@ jobs:
         pip install coveralls
 
     - name: Run Unittest
-      env:
-        LUCIT_API_SECRET: ${{ secrets.LUCIT_API_SECRET }}
-        LUCIT_LICENSE_TOKEN: ${{ secrets.LUCIT_LICENSE_TOKEN }}
       run: coverage run --source unicorn_binance_rest_api unittest_binance_rest_api.py
 
   test_python_3_10:
@@ -50,9 +47,6 @@ jobs:
         pip install coveralls
 
     - name: Run Unittest
-      env:
-        LUCIT_API_SECRET: ${{ secrets.LUCIT_API_SECRET }}
-        LUCIT_LICENSE_TOKEN: ${{ secrets.LUCIT_LICENSE_TOKEN }}
       run: coverage run --source unicorn_binance_rest_api unittest_binance_rest_api.py
 
   test_python_3_11:
@@ -74,9 +68,6 @@ jobs:
         pip install coveralls
 
     - name: Run Unittest
-      env:
-        LUCIT_API_SECRET: ${{ secrets.LUCIT_API_SECRET }}
-        LUCIT_LICENSE_TOKEN: ${{ secrets.LUCIT_LICENSE_TOKEN }}
       run: coverage run --source unicorn_binance_rest_api unittest_binance_rest_api.py
 
   test_python_3_12:
@@ -98,9 +89,6 @@ jobs:
         pip install coveralls
 
     - name: Run Unittest
-      env:
-        LUCIT_API_SECRET: ${{ secrets.LUCIT_API_SECRET }}
-        LUCIT_LICENSE_TOKEN: ${{ secrets.LUCIT_LICENSE_TOKEN }}
       run: coverage run --source unicorn_binance_rest_api unittest_binance_rest_api.py
 
   test_python_3_13:
@@ -122,9 +110,6 @@ jobs:
         pip install coveralls
 
     - name: Run Unittest
-      env:
-        LUCIT_API_SECRET: ${{ secrets.LUCIT_API_SECRET }}
-        LUCIT_LICENSE_TOKEN: ${{ secrets.LUCIT_LICENSE_TOKEN }}
       run: coverage run --source unicorn_binance_rest_api unittest_binance_rest_api.py
 
     - name: Upload coverage to Codecov
@@ -154,8 +139,5 @@ jobs:
         pip install coveralls
 
     - name: Run Unittest
-      env:
-        LUCIT_API_SECRET: ${{ secrets.LUCIT_API_SECRET }}
-        LUCIT_LICENSE_TOKEN: ${{ secrets.LUCIT_LICENSE_TOKEN }}
       run: coverage run --source unicorn_binance_rest_api unittest_binance_rest_api.py
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## 2.10.0.dev (development stage/unreleased/unstable)
 ### Changed
+- `.github/workflows/unit-tests.yml`: removed the obsolete
+  `LUCIT_API_SECRET` / `LUCIT_LICENSE_TOKEN` environment block from
+  all Python-version test matrices. The LUCIT licensing manager was
+  removed from the codebase; these secrets are no longer referenced.
+- `examples/_archive/*.py` (11 files): updated file headers —
+  `PyPI: lucit-licensing-python` → `unicorn-binance-rest-api`,
+  `License: LSOSL` → `MIT`, and copyright from
+  `LUCIT Systems and Development` to `Oliver Zehentleitner`.
+- `examples/README.md`: removed the lucit.tech chat support link.
+- `SECURITY.md`: replaced the lucit.tech contact form URL with the
+  GitHub Security Advisories private-reporting URL.
 - `environment.yml`: dropped the `defaults` channel (conda-forge docs
   recommend not mixing channels; Anaconda `defaults` requires a paid
   license for enterprise use since 2024). Moved `service-identity` out

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,12 +7,12 @@ This document outlines security procedures and general policies for the
   * [Comments on this Policy](#comments-on-this-policy)
 
 ## Reporting a Bug
-`LUCIT Systems and Development` takes all security bugs in `unicorn-binance-rest-api` seriously.
+`Oliver Zehentleitner` takes all security bugs in `unicorn-binance-rest-api` seriously.
 Thank you for improving the security of `unicorn-binance-rest-api`. We appreciate your 
 efforts and responsible disclosure and will make every effort to acknowledge your contributions.
 
-Report security bugs via our contact form: 
-https://www.lucit.tech/contact-unicorn-developers.html
+Please report security bugs privately via GitHub Security Advisories:
+https://github.com/oliver-zehentleitner/unicorn-binance-rest-api/security/advisories/new
 
 The lead maintainer will acknowledge your email within 48 hours, and will send a
 more detailed response within 48 hours indicating the next steps in handling

--- a/examples/README.md
+++ b/examples/README.md
@@ -3,9 +3,8 @@ Here you will find best practice examples for the use of the UNICORN Binance RES
 
 For each example you will find a `README.md` and a `requirements.txt` to install any dependencies. The respective `*.py` 
 file is to download and start, if an example does not work, we are happy about a 
-[patch](https://github.com/oliver-zehentleitner/unicorn-binance-rest-api/fork) or a message via 
-[GitHub Issue](https://github.com/oliver-zehentleitner/unicorn-binance-rest-api/issues/new/choose) or 
-[our chat](https://www.lucit.tech/get-support.html).
+[patch](https://github.com/oliver-zehentleitner/unicorn-binance-rest-api/fork) or a message via
+[GitHub Issue](https://github.com/oliver-zehentleitner/unicorn-binance-rest-api/issues/new/choose).
 
 Old examples are stored in the 
 [archive](https://github.com/oliver-zehentleitner/unicorn-binance-rest-api/tree/master/examples/_archive).

--- a/examples/_archive/example_buy_and_sell_oco_order_isolated_margin.py
+++ b/examples/_archive/example_buy_and_sell_oco_order_isolated_margin.py
@@ -7,14 +7,14 @@
 # Project website: https://github.com/oliver-zehentleitner/unicorn-binance-rest-api
 # Github: https://github.com/oliver-zehentleitner/unicorn-binance-rest-api
 # Documentation: https://oliver-zehentleitner.github.io/unicorn-binance-rest-api/
-# PyPI: https://pypi.org/project/lucit-licensing-python
+# PyPI: https://pypi.org/project/unicorn-binance-rest-api
 #
-# License: LSOSL - LUCIT Synergetic Open Source License
-# https://github.com/oliver-zehentleitner/lucit-licensing-python/blob/master/LICENSE
+# License: MIT
+# https://github.com/oliver-zehentleitner/unicorn-binance-rest-api/blob/master/LICENSE
 #
 # Author: Oliver Zehentleitner
 #
-# Copyright (c) 2021-2023, LUCIT Systems and Development (https://www.lucit.tech)
+# Copyright (c) 2021-2026, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 # All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a

--- a/examples/_archive/example_doing_something.py
+++ b/examples/_archive/example_doing_something.py
@@ -7,14 +7,14 @@
 # Project website: https://github.com/oliver-zehentleitner/unicorn-binance-rest-api
 # Github: https://github.com/oliver-zehentleitner/unicorn-binance-rest-api
 # Documentation: https://oliver-zehentleitner.github.io/unicorn-binance-rest-api/
-# PyPI: https://pypi.org/project/lucit-licensing-python
+# PyPI: https://pypi.org/project/unicorn-binance-rest-api
 #
-# License: LSOSL - LUCIT Synergetic Open Source License
-# https://github.com/oliver-zehentleitner/lucit-licensing-python/blob/master/LICENSE
+# License: MIT
+# https://github.com/oliver-zehentleitner/unicorn-binance-rest-api/blob/master/LICENSE
 #
 # Author: Oliver Zehentleitner
 #
-# Copyright (c) 2021-2023, LUCIT Systems and Development (https://www.lucit.tech)
+# Copyright (c) 2021-2026, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 # All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a

--- a/examples/_archive/example_easy_migration_from_python-binance.py
+++ b/examples/_archive/example_easy_migration_from_python-binance.py
@@ -7,15 +7,15 @@
 # Project website: https://github.com/oliver-zehentleitner/unicorn-binance-rest-api
 # Github: https://github.com/oliver-zehentleitner/unicorn-binance-rest-api
 # Documentation: https://oliver-zehentleitner.github.io/unicorn-binance-rest-api/
-# PyPI: https://pypi.org/project/lucit-licensing-python
+# PyPI: https://pypi.org/project/unicorn-binance-rest-api
 #
-# License: LSOSL - LUCIT Synergetic Open Source License
-# https://github.com/oliver-zehentleitner/lucit-licensing-python/blob/master/LICENSE
+# License: MIT
+# https://github.com/oliver-zehentleitner/unicorn-binance-rest-api/blob/master/LICENSE
 #
 # Author: Oliver Zehentleitner
 #
 # Copyright (c) 2017-2021, Sam McHardy (https://github.com/sammchardy)
-# Copyright (c) 2021-2023, LUCIT Systems and Development (https://www.lucit.tech)
+# Copyright (c) 2021-2026, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 # All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a

--- a/examples/_archive/example_exchange_endpoints.py
+++ b/examples/_archive/example_exchange_endpoints.py
@@ -7,14 +7,14 @@
 # Project website: https://github.com/oliver-zehentleitner/unicorn-binance-rest-api
 # Github: https://github.com/oliver-zehentleitner/unicorn-binance-rest-api
 # Documentation: https://oliver-zehentleitner.github.io/unicorn-binance-rest-api/
-# PyPI: https://pypi.org/project/lucit-licensing-python
+# PyPI: https://pypi.org/project/unicorn-binance-rest-api
 #
-# License: LSOSL - LUCIT Synergetic Open Source License
-# https://github.com/oliver-zehentleitner/lucit-licensing-python/blob/master/LICENSE
+# License: MIT
+# https://github.com/oliver-zehentleitner/unicorn-binance-rest-api/blob/master/LICENSE
 #
 # Author: Oliver Zehentleitner
 #
-# Copyright (c) 2021-2023, LUCIT Systems and Development (https://www.lucit.tech)
+# Copyright (c) 2021-2026, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 # All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a

--- a/examples/_archive/example_exchange_info.py
+++ b/examples/_archive/example_exchange_info.py
@@ -7,14 +7,14 @@
 # Project website: https://github.com/oliver-zehentleitner/unicorn-binance-rest-api
 # Github: https://github.com/oliver-zehentleitner/unicorn-binance-rest-api
 # Documentation: https://oliver-zehentleitner.github.io/unicorn-binance-rest-api/
-# PyPI: https://pypi.org/project/lucit-licensing-python
+# PyPI: https://pypi.org/project/unicorn-binance-rest-api
 #
-# License: LSOSL - LUCIT Synergetic Open Source License
-# https://github.com/oliver-zehentleitner/lucit-licensing-python/blob/master/LICENSE
+# License: MIT
+# https://github.com/oliver-zehentleitner/unicorn-binance-rest-api/blob/master/LICENSE
 #
 # Author: Oliver Zehentleitner
 #
-# Copyright (c) 2021-2023, LUCIT Systems and Development (https://www.lucit.tech)
+# Copyright (c) 2021-2026, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 # All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a

--- a/examples/_archive/example_futures_commission_rate.py
+++ b/examples/_archive/example_futures_commission_rate.py
@@ -7,14 +7,14 @@
 # Project website: https://github.com/oliver-zehentleitner/unicorn-binance-rest-api
 # Github: https://github.com/oliver-zehentleitner/unicorn-binance-rest-api
 # Documentation: https://oliver-zehentleitner.github.io/unicorn-binance-rest-api/
-# PyPI: https://pypi.org/project/lucit-licensing-python
+# PyPI: https://pypi.org/project/unicorn-binance-rest-api
 #
-# License: LSOSL - LUCIT Synergetic Open Source License
-# https://github.com/oliver-zehentleitner/lucit-licensing-python/blob/master/LICENSE
+# License: MIT
+# https://github.com/oliver-zehentleitner/unicorn-binance-rest-api/blob/master/LICENSE
 #
 # Author: Oliver Zehentleitner
 #
-# Copyright (c) 2021-2023, LUCIT Systems and Development (https://www.lucit.tech)
+# Copyright (c) 2021-2026, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 # All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a

--- a/examples/_archive/example_historical_data.py
+++ b/examples/_archive/example_historical_data.py
@@ -7,14 +7,14 @@
 # Project website: https://github.com/oliver-zehentleitner/unicorn-binance-rest-api
 # Github: https://github.com/oliver-zehentleitner/unicorn-binance-rest-api
 # Documentation: https://oliver-zehentleitner.github.io/unicorn-binance-rest-api/
-# PyPI: https://pypi.org/project/lucit-licensing-python
+# PyPI: https://pypi.org/project/unicorn-binance-rest-api
 #
-# License: LSOSL - LUCIT Synergetic Open Source License
-# https://github.com/oliver-zehentleitner/lucit-licensing-python/blob/master/LICENSE
+# License: MIT
+# https://github.com/oliver-zehentleitner/unicorn-binance-rest-api/blob/master/LICENSE
 #
 # Author: Oliver Zehentleitner
 #
-# Copyright (c) 2021-2023, LUCIT Systems and Development (https://www.lucit.tech)
+# Copyright (c) 2021-2026, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 # All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a

--- a/examples/_archive/example_logging.py
+++ b/examples/_archive/example_logging.py
@@ -7,14 +7,14 @@
 # Project website: https://github.com/oliver-zehentleitner/unicorn-binance-rest-api
 # Github: https://github.com/oliver-zehentleitner/unicorn-binance-rest-api
 # Documentation: https://oliver-zehentleitner.github.io/unicorn-binance-rest-api/
-# PyPI: https://pypi.org/project/lucit-licensing-python
+# PyPI: https://pypi.org/project/unicorn-binance-rest-api
 #
-# License: LSOSL - LUCIT Synergetic Open Source License
-# https://github.com/oliver-zehentleitner/lucit-licensing-python/blob/master/LICENSE
+# License: MIT
+# https://github.com/oliver-zehentleitner/unicorn-binance-rest-api/blob/master/LICENSE
 #
 # Author: Oliver Zehentleitner
 #
-# Copyright (c) 2021-2023, LUCIT Systems and Development (https://www.lucit.tech)
+# Copyright (c) 2021-2026, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 # All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a

--- a/examples/_archive/example_orders.py
+++ b/examples/_archive/example_orders.py
@@ -7,14 +7,14 @@
 # Project website: https://github.com/oliver-zehentleitner/unicorn-binance-rest-api
 # Github: https://github.com/oliver-zehentleitner/unicorn-binance-rest-api
 # Documentation: https://oliver-zehentleitner.github.io/unicorn-binance-rest-api/
-# PyPI: https://pypi.org/project/lucit-licensing-python
+# PyPI: https://pypi.org/project/unicorn-binance-rest-api
 #
-# License: LSOSL - LUCIT Synergetic Open Source License
-# https://github.com/oliver-zehentleitner/lucit-licensing-python/blob/master/LICENSE
+# License: MIT
+# https://github.com/oliver-zehentleitner/unicorn-binance-rest-api/blob/master/LICENSE
 #
 # Author: Oliver Zehentleitner
 #
-# Copyright (c) 2021-2023, LUCIT Systems and Development (https://www.lucit.tech)
+# Copyright (c) 2021-2026, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 # All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a

--- a/examples/_archive/example_socks5_proxy.py
+++ b/examples/_archive/example_socks5_proxy.py
@@ -7,14 +7,14 @@
 # Project website: https://github.com/oliver-zehentleitner/unicorn-binance-rest-api
 # Github: https://github.com/oliver-zehentleitner/unicorn-binance-rest-api
 # Documentation: https://oliver-zehentleitner.github.io/unicorn-binance-rest-api/
-# PyPI: https://pypi.org/project/lucit-licensing-python
+# PyPI: https://pypi.org/project/unicorn-binance-rest-api
 #
-# License: LSOSL - LUCIT Synergetic Open Source License
-# https://github.com/oliver-zehentleitner/lucit-licensing-python/blob/master/LICENSE
+# License: MIT
+# https://github.com/oliver-zehentleitner/unicorn-binance-rest-api/blob/master/LICENSE
 #
 # Author: Oliver Zehentleitner
 #
-# Copyright (c) 2021-2023, LUCIT Systems and Development (https://www.lucit.tech)
+# Copyright (c) 2021-2026, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 # All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a

--- a/examples/_archive/example_version_of_this_package.py
+++ b/examples/_archive/example_version_of_this_package.py
@@ -14,7 +14,7 @@
 #
 # Author: Oliver Zehentleitner
 #
-# Copyright (c) 2022-2024, LUCIT Systems and Development (https://www.lucit.tech)
+# Copyright (c) 2022-2026, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 # All rights reserved.
 
 from unicorn_binance_rest_api import BinanceRestApiManager

--- a/meta.yaml
+++ b/meta.yaml
@@ -76,59 +76,59 @@ about:
     [![Read How To`s](https://img.shields.io/badge/read-%20howto-yellow)](https://technopathy.club)
     [![Github](https://img.shields.io/badge/source-github-cbc2c8)](https://github.com/oliver-zehentleitner/unicorn-binance-rest-api)
     [![Telegram](https://img.shields.io/badge/community-telegram-41ab8c)](https://t.me/unicorndevs)
-    
+
     [![UBS-Banner](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-binance-suite/master/images/logo/UBS-Banner-Readme.png)](https://github.com/oliver-zehentleitner/unicorn-binance-suite)
-    
+
     # UNICORN Binance REST API
-    
+
     [Description](#description) | [Installation](#installation-and-upgrade) | [How To](#howto) |
     [Documentation](#documentation) | [Examples](#examples) | [Change Log](#change-log) | [Wiki](#wiki) | [Social](#social) |
     [Notifications](#receive-notifications) | [Bugs](#how-to-report-bugs-or-suggest-improvements) | 
     [Contributing](#contributing) | [Disclaimer](#disclaimer)
-    
+
     A Python SDK to use the Binance REST API`s (com+testnet, com-margin+testnet, com-isolated_margin+testnet, 
     com-futures+testnet, com-vanilla-options+testnet, us, tr) in a simple, fast, flexible, robust and fully-featured way. 
-    
+
     Part of ['UNICORN Binance Suite'](https://github.com/oliver-zehentleitner/unicorn-binance-suite).
-    
+
     ## Receive Data from Binance REST API Endpoints
-    
+
     ### Initiate `BinanceRestApiManager()`
     ```
     from unicorn_binance_rest_api import BinanceRestApiManager
-    
+
     ubra = BinanceRestApiManager(api_key="YOUR_BINANCE_API_KEY", 
                                  api_secret="YOUR_BINANCE_API_SECRET", 
                                  exchange="binance.com")
     ```
-    
+
     ### Print a snapshot of an order book
     ```
     print(f"BNBBTC order book: {ubra.get_order_book(symbol='BNBBTC')}")
     ```
-    
+
     ### Get all symbol prices
     ```
     print(f"All tickers:\r\n{ubra.get_all_tickers()}")
     ```
-    
+
     ### Get the used weight 
     ***Please Note:*** 
     https://github.com/binance-us/binance-official-api-docs/blob/master/rest-api.md#limits
-    
+
     ```
     print(f"Used weight: {ubra.get_used_weight()}")
     ```
-    
+
     ## Send data to Binance REST API Endpoints
     ### Initiate `BinanceRestApiManager()`
-    
+
     ```
     ubra = BinanceRestApiManager(api_key="YOUR_BINANCE_API_KEY", 
                                  api_secret="YOUR_BINANCE_API_SECRET", 
                                  exchange="binance.com-isolated_margin")
     ```
-    
+
     ### Buy BTC with a market order using 100 USDT
     ```
     buy_order = ubra.create_margin_order(symbol="BTCUSDT",
@@ -138,26 +138,26 @@ about:
                                          quoteOrderQty=100)
     print(f"Buy Order Result: {buy_order}")
     ```
-    
+
     ## Stop `ubra` after usage to avoid memory leaks
-    
+
     When you instantiate UBRA with `with`, `ubra.stop_manager()` is automatically executed upon exiting the `with`-block.
-    
+
     ```
     with BinanceRestApiManager() as ubra:
         depth = ubra.get_order_book(symbol='BNBBTC')
     ```
-    
+
     Without `with`, you must explicitly execute `ubra.stop_manager()` yourself.
-    
+
     ```
     ubra.stop_manager()
     ```
-    
+
     ## More?
     [Discover even more possibilities](https://oliver-zehentleitner.github.io/unicorn-binance-rest-api/unicorn_binance_rest_api.html) 
     or try our [examples](#examples)!
-    
+
     ## Description
     The Python module [UNICORN Binance REST API](https://github.com/oliver-zehentleitner/unicorn-binance-rest-api) 
     provides an API to the Binance REST API`s of 
@@ -179,14 +179,14 @@ about:
     [www.binance.com](https://www.binance.com/userCenter/createApi.html), 
     [testnet.binance.vision](https://testnet.binance.vision/) or
     [www.binance.us](https://www.binance.us/userCenter/createApi.html).
-    
+
     Be aware that the Binance REST API is request based. if you want to send and receive high frequency and high volume 
     data, you can use the [UNICORN Binance Websocket API](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api) in 
     combination. 
-    
+
     ### What are the benefits of the UNICORN Binance REST API?
     - Supported exchanges:
-    
+
     | Exchange                                                           | Exchange string                       |
     |--------------------------------------------------------------------|---------------------------------------|
     | [Binance](https://www.binance.com)                                 | `binance.com`                         |
@@ -202,17 +202,17 @@ about:
     | [Binance European Options Testnet](https://testnet.binancefuture.com) | `binance.com-vanilla-options-testnet` |
     | [Binance US](https://www.binance.us)                               | `binance.us`                          |
     | [Binance TR](https://www.trbinance.com)                            | `trbinance.com`                       |
-    
+
     - Helpful management features like 
     [`get_used_weight()`](https://oliver-zehentleitner.github.io/unicorn-binance-rest-api/unicorn_binance_rest_api.html#unicorn_binance_rest_api.manager.BinanceRestApiManager.get_used_weight), 
-    
+
     - Available as a package via `pip` and `conda` as precompiled C extension with stub files for improved Intellisense 
       functions and source code for easier debugging of the source code. [To the installation.](#installation-and-upgrade)
-    
+
     - Integration of [test cases](https://github.com/oliver-zehentleitner/unicorn-binance-rest-api/actions/workflows/unit-tests.yml) and [examples](#examples).
-    
+
     - Customizable base URL and request timeout.
-    
+
     - *Socks5 Proxy* support:
       ```
       ubra = BinanceRestApiManager(exchange="binance.com", socks5_proxy_server="127.0.0.1:9050") 
@@ -221,22 +221,22 @@ about:
       or this [how to](https://medium.com/@oliverzehentleitner/how-to-connect-to-binance-com-rest-api-using-python-via-a-socks5-proxy-638dbbecacfd) 
       for more information or try 
       [example_socks5_proxy.py](https://github.com/oliver-zehentleitner/unicorn-binance-rest-api/blob/master/examples/_archive/example_socks5_proxy.py).
-    
+
     - Excessively tested on Linux, Mac and Windows
-    
+
     If you like the project, please [![star](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-binance-rest-api/master/images/misc/star.png)](https://github.com/oliver-zehentleitner/unicorn-binance-rest-api/stargazers) it on 
     [GitHub](https://github.com/oliver-zehentleitner/unicorn-binance-rest-api)!
-    
+
     ## Installation and Upgrade
     The module requires Python 3.9 and runs smoothly up to and including Python 3.14.
-    
-    For the PyPy interpreter we offer packages only from Python version 3.9 and higher.
-    
+
+    PyPy wheels are available for all supported Python versions.
+
     The current dependencies are listed 
     [here](https://github.com/oliver-zehentleitner/unicorn-binance-rest-api/blob/master/requirements.txt).
-    
+
     If you run into errors during the installation take a look [here](https://github.com/oliver-zehentleitner/unicorn-binance-suite/wiki/Installation).
-    
+
     ### Packages are created automatically with GitHub Actions
     When a new release is created, the
     [Build and Publish GH+PyPi](https://github.com/oliver-zehentleitner/unicorn-binance-rest-api/actions/workflows/build_wheels.yml)
@@ -245,55 +245,55 @@ about:
     [conda-forge/unicorn-binance-rest-api-feedstock](https://github.com/conda-forge/unicorn-binance-rest-api-feedstock)
     picks up the new PyPI release automatically and builds the Conda packages on its own infrastructure.
     This is a transparent method that makes it possible to trace the source code behind a compilation.
-    
+
     ### A Cython binary, PyPy or source code based CPython wheel of the latest version with `pip` from [PyPI](https://pypi.org/project/unicorn-binance-rest-api/)
     Our [Cython](https://cython.org/) and [PyPy](https://www.pypy.org/) Wheels are available on [PyPI](https://pypi.org/), 
     these wheels offer significant advantages for Python developers:
-    
+
     - ***Performance Boost with Cython Wheels:*** Cython is a programming language that supplements Python with static typing and C-level performance. By compiling 
       Python code into C, Cython Wheels can significantly enhance the execution speed of Python code, especially in 
       computationally intensive tasks. This means faster runtimes and more efficient processing for users of our package. 
-    
+
     - ***PyPy Wheels for Enhanced Efficiency:*** PyPy is an alternative Python interpreter known for its speed and efficiency. It uses Just-In-Time (JIT) compilation, 
       which can dramatically improve the performance of Python code. Our PyPy Wheels are tailored for compatibility with 
       PyPy, allowing users to leverage this speed advantage seamlessly.
-    
+
     Both Cython and PyPy Wheels on PyPI make the installation process simpler and more straightforward. They ensure that 
     you get the optimized version of our package with minimal setup, allowing you to focus on development rather than 
     configuration.
-    
+
     On Raspberry Pi and other architectures for which there are no pre-compiled versions, the package can still be 
     installed with PIP. PIP then compiles the package locally on the target system during installation. Please be patient, 
     this may take some time!
-    
+
     #### Installation
     `pip install unicorn-binance-rest-api`
-    
+
     #### Update
     `pip install unicorn-binance-rest-api --upgrade`
-    
+
     ### conda
     ```
     conda install -c conda-forge unicorn-binance-rest-api
     ```
-    
+
     ### From source of the latest release with PIP from [GitHub](https://github.com/oliver-zehentleitner/unicorn-binance-rest-api)
     #### Linux, macOS, ...
     Run in bash:
-    
+
     `pip install https://github.com/oliver-zehentleitner/unicorn-binance-rest-api/archive/$(curl -s https://api.github.com/repos/oliver-zehentleitner/unicorn-binance-rest-api/releases/latest | grep -oP '"tag_name": "\K(.*)(?=")').tar.gz --upgrade`
-    
+
     #### Windows
     Use the below command with the version (such as 2.10.0) you determined 
     [here](https://github.com/oliver-zehentleitner/unicorn-binance-rest-api/releases/latest):
-    
+
     `pip install https://github.com/oliver-zehentleitner/unicorn-binance-rest-api/archive/2.10.0.tar.gz --upgrade`
-    
+
     ### From the latest source (dev-stage) with PIP from [GitHub](https://github.com/oliver-zehentleitner/unicorn-binance-rest-api)
     This is not a release version and can not be considered to be stable!
-    
+
     `pip install https://github.com/oliver-zehentleitner/unicorn-binance-rest-api/tarball/master --upgrade`
-    
+
     ### [Conda environment](https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html), [Virtualenv](https://virtualenv.pypa.io/en/latest/) or plain [Python](https://www.python.org)
     Download the [latest release](https://github.com/oliver-zehentleitner/unicorn-binance-rest-api/releases/latest) 
     or the [current master branch](https://github.com/oliver-zehentleitner/unicorn-binance-rest-api/archive/master.zip)
@@ -304,35 +304,35 @@ about:
     - ./pyproject.toml
     - ./requirements.txt
     - ./setup.py
-    
+
     ## Change Log
     [https://oliver-zehentleitner.github.io/unicorn-binance-rest-api/changelog.html](https://oliver-zehentleitner.github.io/unicorn-binance-rest-api/changelog.html)
-    
+
     ## Documentation
     - [General](https://oliver-zehentleitner.github.io/unicorn-binance-rest-api/)
     - [Modules](https://oliver-zehentleitner.github.io/unicorn-binance-rest-api/modules.html)
-    
+
     ## Examples
     - [Look here!](https://github.com/oliver-zehentleitner/unicorn-binance-rest-api/tree/master/examples/)
-    
+
     ## Howto
     - [Restful Binance Requests in Python with UNICORN Binance REST API](https://technopathy.club/restful-binance-requests-in-python-with-unicorn-binance-rest-api-288f364e92a8)
     - [How to Download Klines from Binance using Python?](https://technopathy.club/how-to-download-data-from-binance-using-python-8f1b6e8f19f3)
     - [How to Connect to binance.com REST API using Python via a SOCKS5 Proxy](https://technopathy.club/how-to-connect-to-binance-com-rest-api-using-python-via-a-socks5-proxy-638dbbecacfd)
     - [Buy an Asset and instantly create a Take Profit and Stop Loss OCO Sell Order using Python in Binance Isolated Margin](https://technopathy.club/buy-an-asset-and-instantly-create-a-take-profit-and-stop-loss-oco-sell-order-using-python-in-5d68a5d22a9b)
-    
+
     ## Project Homepage
     [https://github.com/oliver-zehentleitner/unicorn-binance-rest-api](https://github.com/oliver-zehentleitner/unicorn-binance-rest-api)
-    
+
     ## Wiki
     [https://github.com/oliver-zehentleitner/unicorn-binance-rest-api/wiki](https://github.com/oliver-zehentleitner/unicorn-binance-rest-api/wiki)
-    
+
     ## Social
     - [Discussions](https://github.com/oliver-zehentleitner/unicorn-binance-rest-api/discussions)
     - [https://t.me/unicorndevs](https://t.me/unicorndevs)
     - [https://dev.binance.vision](https://dev.binance.vision)
     - [https://forum.bnbchain.org/](https://forum.bnbchain.org/)
-    
+
     ## Receive Notifications
     To receive notifications on available updates you can 
     [![watch](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-binance-rest-api/master/images/misc/watch.png)](https://github.com/oliver-zehentleitner/unicorn-binance-rest-api/watchers) 
@@ -340,27 +340,27 @@ about:
     [own script](https://github.com/oliver-zehentleitner/unicorn-binance-rest-api/blob/master/examples/_archive/example_version_of_this_package.py) 
     with using 
     [`is_update_availabe()`](https://oliver-zehentleitner.github.io/unicorn-binance-rest-api/unicorn_binance_rest_api.html?highlight=is_update_availabe#unicorn_binance_rest_api.manager.BinanceRestApiManager.is_update_availabe).
-    
+
     To receive news (like inspection windows/maintenance) about the Binance API`s subscribe to their telegram groups: 
-    
+
     - [https://t.me/binance_api_announcements](https://t.me/binance_api_announcements)
     - [https://t.me/binance_api_english](https://t.me/binance_api_english)
     - [https://t.me/Binance_USA](https://t.me/Binance_USA)
     - [https://t.me/TRBinanceTR](https://t.me/TRBinanceTR)
     - [https://t.me/BinanceDEXchange](https://t.me/BinanceDEXchange)
     - [https://t.me/BinanceExchange](https://t.me/BinanceExchange)
-    
+
     ## How to report Bugs or suggest Improvements?
     [List of planned features](https://github.com/oliver-zehentleitner/unicorn-binance-rest-api/issues?q=is%3Aissue+is%3Aopen+label%3Aenhancement) - 
     click ![thumbs-up](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-binance-rest-api/master/images/misc/thumbup.png) if you need one of them or suggest a new feature!
-    
+
     Before you report a bug, [try the latest release](https://github.com/oliver-zehentleitner/unicorn-binance-rest-api#installation-and-upgrade). If the issue still exists, provide the error trace, OS 
     and Python version and explain how to reproduce the error. A demo script is appreciated.
-    
+
     If you don't find an issue related to your topic, please open a new [issue](https://github.com/oliver-zehentleitner/unicorn-binance-rest-api/issues)!
-    
+
     [Report a security bug!](https://github.com/oliver-zehentleitner/unicorn-binance-rest-api/security/policy)
-    
+
     ## Contributing
     [UNICORN Binance REST API](https://github.com/oliver-zehentleitner/unicorn-binance-rest-api) is an open 
     source project which welcomes contributions which can be anything from simple documentation fixes and reporting dead links to new features. To 
@@ -369,34 +369,34 @@ about:
      
     ### Contributors
     [![Contributors](https://contributors-img.web.app/image?repo=oliver-zehentleitner/unicorn-binance-rest-api)](https://github.com/oliver-zehentleitner/unicorn-binance-rest-api/graphs/contributors)
-    
+
     We ![love](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-binance-rest-api/master/images/misc/heart.png) open source!
-    
+
     ---
-    
+
     ## AI Integration
-    
+
     This project provides a [`llms.txt`](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-binance-rest-api/refs/heads/master/llms.txt) file for AI tools (ChatGPT, Claude, Copilot, etc.) with structured 
     usage instructions, code examples and module routing.
-    
+
     ---
-    
+
     ## Disclaimer
     This project is for informational purposes only. You should not construe this information or any other material as 
     legal, tax, investment, financial or other advice. Nothing contained herein constitutes a solicitation, recommendation, 
     endorsement or offer by us or any third party provider to buy or sell any securities or other financial instruments in 
     this or any other jurisdiction in which such solicitation or offer would be unlawful under the securities laws of such 
     jurisdiction.
-    
+
     ### If you intend to use real money, use it at your own risk!
-    
+
     Under no circumstances will we be responsible or liable for any claims, damages, losses, expenses, costs or liabilities 
     of any kind, including but not limited to direct or indirect damages for loss of profits.
-    
+
     ### SOCKS5 Proxy / Geoblocking
     We would like to explicitly point out that in our opinion US citizens are exclusively authorized to trade on Binance.US 
     and that this restriction must not be circumvented!
-    
+
     The purpose of supporting a SOCKS5 proxy in the UNICORN Binance Suite and its modules is to allow non-US citizens to use 
     US services. For example, GitHub actions with UBS will not work without a SOCKS5 proxy, as they will inevitably run on 
     servers in the US and be blocked by Binance.com. Moreover, it also seems justified that traders, data scientists and 


### PR DESCRIPTION
### CI
- `.github/workflows/unit-tests.yml`: removed the `LUCIT_API_SECRET` / `LUCIT_LICENSE_TOKEN` env blocks from all Python-version test jobs. The LUCIT licensing manager was removed from the codebase; these secrets are no longer referenced.

### Archived examples
- `examples/_archive/*.py` (11 files): file header fixes —
  - `PyPI: lucit-licensing-python` → `unicorn-binance-rest-api`
  - `License: LSOSL - LUCIT Synergetic Open Source License` → `MIT`
  - Copyright `LUCIT Systems and Development` → `Oliver Zehentleitner`

### Misc
- `examples/README.md`: removed `our chat` support link (lucit.tech support page).
- `SECURITY.md`: replaced the lucit.tech contact form URL with the GitHub Security Advisories private-reporting URL.

Sphinx sources and historical CHANGELOG entries intentionally untouched.