### PR TITLE
README: note that conda-forge packages start at Python 3.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,9 @@ The module requires Python 3.9 and runs smoothly up to and including Python 3.14
 
 PyPy wheels are available for all supported Python versions.
 
+**conda-forge note:** Conda packages are provided for Python 3.10 – 3.14. Python 3.9 is not available on conda-forge — it was dropped from the global pinning after reaching end-of-life in October 2025. For Python 3.9, use `pip install`.
+
+
 The current dependencies are listed 
 [here](https://github.com/oliver-zehentleitner/unicorn-binance-rest-api/blob/master/requirements.txt).
 


### PR DESCRIPTION
conda-forge dropped Python 3.9 from the global pinning after Python 3.9 reached end-of-life in October 2025. So while PyPI wheels still cover 3.9, conda-forge packages only cover 3.10 – 3.14. Spelling that out next to the install instructions so users don't hit an unhelpful "package not available" resolver error when trying `conda install` on a Python 3.9 environment.