### PR TITLE
chore: bump copyright year to 2026

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,7 +131,7 @@ python setup.py bdist_wheel
 
 ## Code Conventions
 
-- **File header:** Always include the full MIT license block with dual copyright (2017-2021 Sam McHardy + 2021-2025 Oliver Zehentleitner)
+- **File header:** Always include the full MIT license block with dual copyright (2017-2021 Sam McHardy + 2021-2026 Oliver Zehentleitner)
 - **Encoding:** UTF-8, UNIX line endings
 - **Logging:** `logging.getLogger("unicorn_binance_rest_api")`
 - **JSON:** `ujson` — do not switch to stdlib `json` or `simplejson`

--- a/LICENSE
+++ b/LICENSE
@@ -2,7 +2,7 @@ MIT License
 ===========
 
 Copyright (c) 2017-2021 Sam McHardy, https://github.com/sammchardy
-Copyright (c) 2021-2025 Oliver Zehentleitner, https://about.me/oliver-zehentleitner
+Copyright (c) 2021-2026 Oliver Zehentleitner, https://about.me/oliver-zehentleitner
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/dev/pypi/create_wheel.sh
+++ b/dev/pypi/create_wheel.sh
@@ -15,7 +15,7 @@
 # Author: Oliver Zehentleitner
 #
 # Copyright (c) 2017-2021, MIT License, Sam McHardy (https://github.com/sammchardy)
-# Copyright (c) 2021-2025, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
+# Copyright (c) 2021-2026, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 #
 # All rights reserved.
 #

--- a/dev/pypi/install_packaging_tools.sh
+++ b/dev/pypi/install_packaging_tools.sh
@@ -15,7 +15,7 @@
 # Author: Oliver Zehentleitner
 #
 # Copyright (c) 2017-2021, MIT License, Sam McHardy (https://github.com/sammchardy)
-# Copyright (c) 2021-2025, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
+# Copyright (c) 2021-2026, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 #
 # All rights reserved.
 #

--- a/dev/pypi/remove_files.sh
+++ b/dev/pypi/remove_files.sh
@@ -15,7 +15,7 @@
 # Author: Oliver Zehentleitner
 #
 # Copyright (c) 2017-2021, MIT License, Sam McHardy (https://github.com/sammchardy)
-# Copyright (c) 2021-2025, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
+# Copyright (c) 2021-2026, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 #
 # All rights reserved.
 #

--- a/dev/pypi/upload_wheel.sh
+++ b/dev/pypi/upload_wheel.sh
@@ -15,7 +15,7 @@
 # Author: Oliver Zehentleitner
 #
 # Copyright (c) 2017-2021, MIT License, Sam McHardy (https://github.com/sammchardy)
-# Copyright (c) 2021-2025, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
+# Copyright (c) 2021-2026, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 #
 # All rights reserved.
 #

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@
 # Author: Oliver Zehentleitner
 #
 # Copyright (c) 2017-2021, MIT License, Sam McHardy (https://github.com/sammchardy)
-# Copyright (c) 2021-2025, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
+# Copyright (c) 2021-2026, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 #
 # All rights reserved.
 #

--- a/unicorn_binance_rest_api/enums.py
+++ b/unicorn_binance_rest_api/enums.py
@@ -16,7 +16,7 @@
 # Author: Oliver Zehentleitner
 #
 # Copyright (c) 2017-2021, MIT License, Sam McHardy (https://github.com/sammchardy)
-# Copyright (c) 2021-2025, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
+# Copyright (c) 2021-2026, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 #
 # All rights reserved.
 #

--- a/unicorn_binance_rest_api/exceptions.py
+++ b/unicorn_binance_rest_api/exceptions.py
@@ -16,7 +16,7 @@
 # Author: Oliver Zehentleitner
 #
 # Copyright (c) 2017-2021, MIT License, Sam McHardy (https://github.com/sammchardy)
-# Copyright (c) 2021-2025, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
+# Copyright (c) 2021-2026, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 #
 # All rights reserved.
 #

--- a/unicorn_binance_rest_api/helpers.py
+++ b/unicorn_binance_rest_api/helpers.py
@@ -16,7 +16,7 @@
 # Author: Oliver Zehentleitner
 #
 # Copyright (c) 2017-2021, MIT License, Sam McHardy (https://github.com/sammchardy)
-# Copyright (c) 2021-2025, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
+# Copyright (c) 2021-2026, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 #
 # All rights reserved.
 #

--- a/unicorn_binance_rest_api/manager.py
+++ b/unicorn_binance_rest_api/manager.py
@@ -16,7 +16,7 @@
 # Author: Oliver Zehentleitner
 #
 # Copyright (c) 2017-2021, MIT License, Sam McHardy (https://github.com/sammchardy)
-# Copyright (c) 2021-2025, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
+# Copyright (c) 2021-2026, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 #
 # All rights reserved.
 #


### PR DESCRIPTION
## Summary
- Bump copyright year from 2025 to 2026 in LICENSE + source headers
- Pattern: only modify lines containing \`Copyright\` to avoid touching unrelated 2025 occurrences
- Auto-generated files (\`docs/\`, \`dev/sphinx/\`) intentionally untouched — regenerated on next build

## Test plan
- [ ] LICENSE shows 2021-2026
- [ ] No unintended 2025→2026 changes in non-copyright lines