### PR TITLE
docs: link The Complete Binance Python API Guide 2026

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ or the [current master branch](https://github.com/oliver-zehentleitner/unicorn-b
 - [Look here!](https://github.com/oliver-zehentleitner/unicorn-binance-rest-api/tree/master/examples/)
 
 ## Related Articles
+- [The Complete Binance Python API Guide 2026](https://blog.technopathy.club/the-complete-binance-python-api-guide-2026)
 - [How to create a Binance API Key and API Secret?](https://blog.technopathy.club/how-to-create-a-binance-api-key-and-api-secret)
 - [Restful Binance Requests in Python with UNICORN Binance REST API](https://blog.technopathy.club/restful-binance-requests-in-python-with-unicorn-binance-rest-api)
 - [How to Download Klines from Binance using Python?](https://blog.technopathy.club/how-to-download-klines-from-binance-using-python)

--- a/llms.txt
+++ b/llms.txt
@@ -124,6 +124,10 @@ except BinanceAPIException as e:
 
 Each of these can be given an existing `BinanceRestApiManager` via `ubra_manager=...` to share a single instance across the suite.
 
+## Related Articles
+
+- [The Complete Binance Python API Guide 2026](https://blog.technopathy.club/the-complete-binance-python-api-guide-2026) — comprehensive 2026 overview of building Binance trading systems in Python; positions UBRA within the UNICORN Binance Suite landscape (UBWA, UBRA, UBLDC, UBDCC, UBTSL, UnicornFy) and helps users pick the right module.
+
 ## Docs
 
 - Repo: https://github.com/oliver-zehentleitner/unicorn-binance-rest-api


### PR DESCRIPTION
## Summary

Adds the new blog post [The Complete Binance Python API Guide 2026](https://blog.technopathy.club/the-complete-binance-python-api-guide-2026) as the top entry in:

- `README.md` → `## Related Articles`
- `llms.txt` → new `## Related Articles` section (didn't exist yet) with an LLM-oriented description

## Test plan

- [ ] Render README on GitHub and verify link position
- [ ] Open the link, confirm it resolves