### PR TITLE
Add Keep the Why setup: context/, config block, badge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,5 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+AGENTS.local.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,10 @@
 > **End-user cheatsheet for AI-assisted consumption:** [`llms.txt`](llms.txt) — use that one if you're writing code *against* this SDK.
 > **This file** is for AI agents working *on* this repo itself.
 
+## Why things are the way they are
+
+See [`context/index.md`](context/index.md) before making non-trivial changes — it points to the reasoning behind design decisions, rejected alternatives, and constraints that aren't visible in the code. If `AGENTS.local.md` exists in this repo, that's personal/local notes, not relevant to anyone else.
+
 ## Planning & Backlog
 
 Open development tasks and decisions are tracked in **[TASKS.md](TASKS.md)**.
@@ -61,29 +65,24 @@ dev/sphinx/                    # Sphinx source for rebuilding docs
 Portfolio Margin (`binance.com-portfolio_margin`) is scoped to the PAPI
 `listenKey` endpoints only — `portfolio_margin_stream_get_listen_key()`,
 `portfolio_margin_stream_keepalive()`, `portfolio_margin_stream_close()`
-(`PAPI_URL = https://papi.binance.com/papi`). This is the minimum UBRA needs
-so that UBWA can open a Portfolio Margin user data stream. The rest of the
-PAPI surface (account, positions, orders, etc.) is intentionally not
-implemented yet — a full UBRA rewrite (unifying async/sync) is planned and
-that's where broader Portfolio Margin coverage will be designed properly.
+(`PAPI_URL = https://papi.binance.com/papi`). Why the scope is this narrow:
+[`context/portfolio-margin.md`](context/portfolio-margin.md).
 
 ---
 
 ## Dependencies
 
-Managed in `requirements.txt`, `setup.py`, `pyproject.toml`, `environment.yml`, and `meta.yaml` — **all five must be kept in sync manually**:
+Managed in `requirements.txt`, `setup.py`, `pyproject.toml`, `environment.yml`, and `meta.yaml` — **all five must be kept in sync manually** (why, and a real drift incident: [`context/history.md`](context/history.md)):
 
-- `requests>=2.31.0` — HTTP client
-- `ujson` — fast JSON parsing
-- `certifi>=2023.7.22` — TLS certificates
-- `cryptography>=42.0.4` — signature/encryption
+- `requests>=2.32.4` — HTTP client
+- `certifi>=2025.6.15` — TLS certificates
+- `cryptography>=45.0.4` — signature/encryption
 - `pyOpenSSL` — SSL support
 - `service-identity` — SSL identity verification
-- `colorama` — colored terminal output
+- `colorama` — colored terminal output (see [`context/testing.md`](context/testing.md) for the `wrap=False` gotcha)
 - `dateparser` — date string parsing
 - `regex` — regex utilities
 - `PySocks` — SOCKS5 proxy support
-- `pytz` — timezone handling
 - `Cython` — C extension compilation (release builds only)
 
 ---
@@ -110,7 +109,7 @@ coverage run --source unicorn_binance_rest_api unittest_binance_rest_api.py
 python unittest_binance_rest_api.py
 ```
 
-Tests in `dev/` are local integration tests that require live Binance credentials — they are **not run in CI**.
+Tests in `dev/` are local integration tests that require live Binance credentials — they are **not run in CI**. CI initializes against `binance.us`, not `binance.com` — see [`context/testing.md`](context/testing.md).
 
 ---
 
@@ -135,7 +134,8 @@ python setup.py bdist_wheel
 - `unit-tests.yml` — Python matrix on Ubuntu, Codecov upload
 - `build_wheels.yml` — Manual trigger, builds wheels for Linux/macOS/Windows, PyPI release
 - `codeql-analysis.yml` — Security scanning
-- `build_conda.yml` — Conda package build
+
+No in-repo conda build — conda-forge's own feedstock is the only conda source (see [`context/history.md`](context/history.md)).
 
 ---
 
@@ -144,7 +144,7 @@ python setup.py bdist_wheel
 - **File header:** Always include the full MIT license block with dual copyright (2017-2021 Sam McHardy + 2021-2026 Oliver Zehentleitner)
 - **Encoding:** UTF-8, UNIX line endings
 - **Logging:** `logging.getLogger("unicorn_binance_rest_api")`
-- **JSON:** `ujson` — do not switch to stdlib `json` or `simplejson`
+- **JSON:** decoded via `requests`' built-in `Response.json()` — no separate JSON library
 - **Cython:** Core module compiles to C extension for releases — no `#cython:` directives needed in source
 - **Versioning:** Keep version in sync across `setup.py`, `pyproject.toml`, and `manager.py` manually
 
@@ -186,3 +186,8 @@ ubra_futures = BinanceRestApiManager(exchange="binance.com-futures")
 - `unicorn-binance-websocket-api` — for listen key management and REST fallbacks
 - `unicorn-binance-trailing-stop-loss` — for order placement and account queries
 - `unicorn-binance-local-depth-cache` — for initial snapshot fetching
+
+<!-- keep-the-why:config -->
+- context: `context/`
+- init: complete
+<!-- /keep-the-why:config -->

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 [![Github](https://img.shields.io/badge/source-github-cbc2c8)](https://github.com/oliver-zehentleitner/unicorn-binance-rest-api)
 [![Telegram](https://img.shields.io/badge/community-telegram-41ab8c)](https://t.me/unicorndevs)
 [![Reddit](https://img.shields.io/badge/community-reddit-41ab8c)](https://www.reddit.com/r/UNICORNBinanceSuite)
+[![Keep the Why](https://keepthewhy.com/assets/badge.svg)](https://keepthewhy.com)
 
 [![UBS-Banner](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-binance-suite/master/images/logo/UBS-Banner-Readme.png)](https://blog.technopathy.club/page/unicorn-binance-suite)
 

--- a/context/README.md
+++ b/context/README.md
@@ -1,0 +1,10 @@
+<img src="https://keepthewhy.com/assets/logo.png" alt="Keep the Why" width="200">
+
+# Context
+
+Why this project is built the way it is — architecture decisions,
+rejected alternatives, workarounds, and reasoning the code alone
+can't show. Captured and kept current by the [Keep the
+Why](https://keepthewhy.com) agent skill.
+
+Not usage docs — see `docs/` for that. Start with `index.md`.

--- a/context/history.md
+++ b/context/history.md
@@ -1,0 +1,21 @@
+# History
+
+## LUCIT-Systems-and-Development origin
+
+**Status:** superseded — repo now lives under `oliver-zehentleitner`, MIT-licensed
+**Confirmed** (git history)
+
+The repo moved into the `LUCIT-Systems-and-Development` GitHub org (commit `e8115d3`, 2022-01-02) and was de-branded back out in a batch of commits on 2025-06-22 ("Removing LUCIT"). Residual cleanup continued much later, in April 2026: conda-forge migration and `build_conda.yml` removal (`31004a2`, 2026-04-18), and a hardcoded old-org URL fix in the update-check code (`3e32159`, 2026-04-13 — `get_latest_release_info()` was still querying `LUCIT-Systems-and-Development`'s GitHub API after the org move).
+
+**Reason:** LUCIT is no longer part of how this project is licensed, distributed, or supported.
+
+**Revisit when:** auditing other suite repos for the same class of bug — a hardcoded org/repo URL in an update-check or "latest release" helper doesn't fail loudly when the org moves, it just silently queries the wrong (possibly stale or gone) place.
+
+## The 5-file dependency sync rule caught its own violation
+
+**Status:** active
+**Confirmed** (commit `9599c72`)
+
+Dependency minimums (in `requirements.txt`, `setup.py`, `pyproject.toml`, `environment.yml`, `meta.yaml`) had drifted independently of each other before this commit — different files disagreed on the actual floor versions, and `ujson` was still listed as a dependency in some of them despite no longer being imported anywhere in the code. Fixed by using `setup.py`'s minimums as the source of truth across all five files and dropping `ujson` entirely.
+
+**Reason:** this validates the "all five must be kept in sync manually" rule already in `AGENTS.md` — it's not a hypothetical risk, the files had actually drifted in practice before this cleanup.

--- a/context/index.md
+++ b/context/index.md
@@ -1,0 +1,5 @@
+# Context index
+
+- [portfolio-margin.md](portfolio-margin.md) — why Portfolio Margin support here is deliberately minimal (listenKey only)
+- [testing.md](testing.md) — why CI tests init against `binance.us`, and the colorama recursion fix
+- [history.md](history.md) — the LUCIT-Systems-and-Development origin, and a dependency-file drift it exposed

--- a/context/portfolio-margin.md
+++ b/context/portfolio-margin.md
@@ -1,0 +1,12 @@
+# Portfolio Margin support
+
+## Deliberately minimal: just enough for UBWA's listenKey needs
+
+**Status:** active
+**Confirmed** (CHANGELOG, 2.11.0.dev entry; issue [#452](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api/issues/452))
+
+This repo's Portfolio Margin (PAPI) support is scoped to the `portfolio_margin_stream_*` listenKey lifecycle methods — just what `unicorn-binance-websocket-api` needs to open a Portfolio Margin user-data stream (see UBWA's own `context/portfolio-margin.md` for the WS-side design).
+
+**Rejected alternative:** implementing broader Portfolio Margin REST coverage (account info, positions, orders, etc.) alongside the listenKey methods, while already touching this code.
+
+**Reason:** broader Portfolio Margin REST coverage is deferred to the planned UBRA rewrite (see the suite's `unicorn-binance-rest-api` v3.0.0 rewrite plan) rather than bolted onto the current architecture piecemeal. The listenKey methods were the minimum needed to unblock UBWA's issue #452.

--- a/context/testing.md
+++ b/context/testing.md
@@ -1,0 +1,21 @@
+# Testing
+
+## CI initializes against `binance.us`, not `binance.com`
+
+**Status:** active
+**Confirmed** (commit `050284a`)
+
+`BinanceRestApiManager.__init__()` makes a live `get_server_time()` call against Binance for every exchange. Test classes that need to exercise a `binance.com`-specific endpoint initialize the manager with `exchange="binance.us"` and then manually override the relevant URL constants (e.g. `PAPI_URL`, `OPTIONS_URL`) for the endpoint actually under test, instead of initializing with `exchange="binance.com"` directly.
+
+**Reason:** GitHub Actions runners are US-based, and Binance blocks `binance.com` API access from restricted (US) locations — a direct `binance.com` init would fail in CI (though it may work fine locally, outside the US). This is the same workaround pattern used in UBWA's and UBTSL's unit tests, for the same reason.
+
+**How to apply:** don't "fix" a test by switching its init back to `binance.com` because it looks more correct — it will pass locally and fail in CI.
+
+## `colorama.init(wrap=False)`
+
+**Status:** active
+**Confirmed** (commit `f8bb80c`)
+
+`colorama.init()` is called with `wrap=False`.
+
+**Reason:** `colorama.init()` wraps `sys.stdout`/`sys.stderr` with `AnsiToWin32`, which overrides `isatty()`. If `BinanceRestApiManager` is instantiated more than once in the same process (e.g. in tests, or a host app creating multiple managers), the stream gets wrapped again on each init, and `isatty()` ends up calling itself recursively until `RecursionError`. `wrap=False` avoids the repeated wrapping.


### PR DESCRIPTION
## Summary
- Adopts the Keep the Why convention: context/portfolio-margin.md (why Portfolio Margin support is deliberately minimal), context/testing.md (why CI runs against binance.us, colorama recursion fix), context/history.md (LUCIT origin, a dependency-file drift incident)
- AGENTS.md trimmed to pointers; fixed stale facts: ujson/pytz no longer deps, build_conda.yml no longer exists, Python compat was listed as 3.8-3.13 (actually 3.9-3.14), stale dependency version floors
- README.md: Keep the Why badge
- .gitignore: AGENTS.local.md (not committed)

## Test plan
- [ ] Read through context/*.md for accuracy against actual history
- [ ] Confirm the dependency-floor and Python-compat corrections match intent