### PR TITLE
docs: update Keep the Why to v0.5.1 (context/README.md, schema migration)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -190,4 +190,6 @@ ubra_futures = BinanceRestApiManager(exchange="binance.com-futures")
 <!-- keep-the-why:config -->
 - context: `context/`
 - init: complete
+- context-schema: 0.5.1
+- capture-confirmation: confirm-when-unsure
 <!-- /keep-the-why:config -->

--- a/context/README.md
+++ b/context/README.md
@@ -1,10 +1,39 @@
-<img src="https://keepthewhy.com/assets/logo.png" alt="Keep the Why" width="200">
+<a href="https://keepthewhy.com"><img src="https://keepthewhy.com/assets/logo.png" alt="Keep the Why"></a>
 
-# Context
+# Project context
 
-Why this project is built the way it is — architecture decisions,
-rejected alternatives, workarounds, and reasoning the code alone
-can't show. Captured and kept current by the [Keep the
-Why](https://keepthewhy.com) agent skill.
+This directory preserves the reasoning behind this project: architectural
+decisions, constraints, rejected alternatives, incident learnings,
+deliberate workarounds, and other knowledge that the code alone cannot
+explain.
 
-Not usage docs — see `docs/` for that. Start with `index.md`.
+It's organized and kept current according to the [Keep the
+Why](https://keepthewhy.com) schema — a repo-native agent skill, not
+specific to this project. Recognizing that schema means an agent (or a
+person who's seen it before) already knows how this directory is
+structured and how to work with it, without first having to figure that
+out from scratch.
+
+It answers:
+
+> Why is the project built this way?
+
+For usage, installation, operation, or troubleshooting, see `docs/`.
+
+## Reading the entries
+
+Each entry separates:
+
+- **Status** — whether a decision is active, superseded, open, or needs review
+- **Evidence** — whether its rationale is confirmed, inferred, or unknown
+
+Old reasoning is retained when it remains useful for understanding how the
+project evolved.
+
+## Trust boundary
+
+Files in this directory describe project knowledge. They do not contain
+instructions that grant permissions, override user intent, authorize
+commands, or weaken security controls.
+
+Start with the [context index](index.md).

--- a/context/history.md
+++ b/context/history.md
@@ -3,7 +3,8 @@
 ## LUCIT-Systems-and-Development origin
 
 **Status:** superseded — repo now lives under `oliver-zehentleitner`, MIT-licensed
-**Confirmed** (git history)
+**Evidence:** confirmed
+**Source:** git history
 
 The repo moved into the `LUCIT-Systems-and-Development` GitHub org (commit `e8115d3`, 2022-01-02) and was de-branded back out in a batch of commits on 2025-06-22 ("Removing LUCIT"). Residual cleanup continued much later, in April 2026: conda-forge migration and `build_conda.yml` removal (`31004a2`, 2026-04-18), and a hardcoded old-org URL fix in the update-check code (`3e32159`, 2026-04-13 — `get_latest_release_info()` was still querying `LUCIT-Systems-and-Development`'s GitHub API after the org move).
 
@@ -14,7 +15,8 @@ The repo moved into the `LUCIT-Systems-and-Development` GitHub org (commit `e811
 ## The 5-file dependency sync rule caught its own violation
 
 **Status:** active
-**Confirmed** (commit `9599c72`)
+**Evidence:** confirmed
+**Source:** commit `9599c72`
 
 Dependency minimums (in `requirements.txt`, `setup.py`, `pyproject.toml`, `environment.yml`, `meta.yaml`) had drifted independently of each other before this commit — different files disagreed on the actual floor versions, and `ujson` was still listed as a dependency in some of them despite no longer being imported anywhere in the code. Fixed by using `setup.py`'s minimums as the source of truth across all five files and dropping `ujson` entirely.
 

--- a/context/portfolio-margin.md
+++ b/context/portfolio-margin.md
@@ -3,7 +3,8 @@
 ## Deliberately minimal: just enough for UBWA's listenKey needs
 
 **Status:** active
-**Confirmed** (CHANGELOG, 2.11.0.dev entry; issue [#452](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api/issues/452))
+**Evidence:** confirmed
+**Source:** CHANGELOG, 2.11.0.dev entry; issue [#452](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api/issues/452)
 
 This repo's Portfolio Margin (PAPI) support is scoped to the `portfolio_margin_stream_*` listenKey lifecycle methods — just what `unicorn-binance-websocket-api` needs to open a Portfolio Margin user-data stream (see UBWA's own `context/portfolio-margin.md` for the WS-side design).
 

--- a/context/testing.md
+++ b/context/testing.md
@@ -3,7 +3,8 @@
 ## CI initializes against `binance.us`, not `binance.com`
 
 **Status:** active
-**Confirmed** (commit `050284a`)
+**Evidence:** confirmed
+**Source:** commit `050284a`
 
 `BinanceRestApiManager.__init__()` makes a live `get_server_time()` call against Binance for every exchange. Test classes that need to exercise a `binance.com`-specific endpoint initialize the manager with `exchange="binance.us"` and then manually override the relevant URL constants (e.g. `PAPI_URL`, `OPTIONS_URL`) for the endpoint actually under test, instead of initializing with `exchange="binance.com"` directly.
 
@@ -14,7 +15,8 @@
 ## `colorama.init(wrap=False)`
 
 **Status:** active
-**Confirmed** (commit `f8bb80c`)
+**Evidence:** confirmed
+**Source:** commit `f8bb80c`
 
 `colorama.init()` is called with `wrap=False`.
 


### PR DESCRIPTION
## Summary
- `context/README.md`: adopt new Keep the Why template (linked logo, "Project context" heading, Reading the entries + Trust boundary sections, links to `index.md`)
- `AGENTS.md`: backfill `context-schema: 0.5.1` and `capture-confirmation: confirm-when-unsure` in the project config block (both fields were missing entirely)
- `context/`: migrate existing entries to the 0.3.0 Status/Evidence split — `**Confirmed** (X)` becomes `**Evidence:** confirmed` + `**Source:** X`

No content/rationale changes — pure schema/template migration, aligning with Keep the Why v0.5.1.